### PR TITLE
Fix seedSampleData idempotency bug

### DIFF
--- a/examples/simpleDemo/main.go
+++ b/examples/simpleDemo/main.go
@@ -66,7 +66,8 @@ func main() {
 
 // seedSampleData inserts sample "logs" and "users" documents so the demo has
 // data to query right away. It connects on its own (independent of the
-// gomongoapi server) and is a no-op if the "logs" collection is non-empty.
+// gomongoapi server) and seeds each collection independently, skipping any
+// collection that is already non-empty.
 func seedSampleData(mongoURI string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -83,38 +84,46 @@ func seedSampleData(mongoURI string) error {
 
 	logs := client.Database(dbName).Collection("logs")
 
-	existing, err := logs.CountDocuments(ctx, bson.M{})
+	logsExisting, err := logs.CountDocuments(ctx, bson.M{})
 	if err != nil {
 		return err
 	}
-	if existing > 0 {
-		return nil
-	}
+	if logsExisting == 0 {
+		countries := []string{"US", "CA", "MX", "BR", "GB", "DE", "FR", "JP"}
+		words := []string{"alpha", "bravo", "charlie", "delta", "echo"}
 
-	countries := []string{"US", "CA", "MX", "BR", "GB", "DE", "FR", "JP"}
-	words := []string{"alpha", "bravo", "charlie", "delta", "echo"}
-
-	now := time.Now()
-	logDocs := make([]any, 0, 200)
-	for i := range 200 {
-		logDocs = append(logDocs, Logs{
-			TimeStamp: now.Add(-time.Duration(i) * time.Hour),
-			Amount:    rand.Float64() * 1000,
-			Country:   countries[rand.Intn(len(countries))],
-			Word:      words[rand.Intn(len(words))],
-			Count:     rand.Intn(100),
-		})
-	}
-	if _, err = logs.InsertMany(ctx, logDocs); err != nil {
-		return err
+		now := time.Now()
+		logDocs := make([]any, 0, 200)
+		for i := range 200 {
+			logDocs = append(logDocs, Logs{
+				TimeStamp: now.Add(-time.Duration(i) * time.Hour),
+				Amount:    rand.Float64() * 1000,
+				Country:   countries[rand.Intn(len(countries))],
+				Word:      words[rand.Intn(len(words))],
+				Count:     rand.Intn(100),
+			})
+		}
+		if _, err = logs.InsertMany(ctx, logDocs); err != nil {
+			return err
+		}
 	}
 
 	users := client.Database(dbName).Collection("users")
-	userDocs := []any{
-		bson.M{"name": "Ada Lovelace", "country": "GB"},
-		bson.M{"name": "Grace Hopper", "country": "US"},
-		bson.M{"name": "Katherine Johnson", "country": "US"},
+
+	usersExisting, err := users.CountDocuments(ctx, bson.M{})
+	if err != nil {
+		return err
 	}
-	_, err = users.InsertMany(ctx, userDocs)
-	return err
+	if usersExisting == 0 {
+		userDocs := []any{
+			bson.M{"name": "Ada Lovelace", "country": "GB"},
+			bson.M{"name": "Grace Hopper", "country": "US"},
+			bson.M{"name": "Katherine Johnson", "country": "US"},
+		}
+		if _, err = users.InsertMany(ctx, userDocs); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
- `seedSampleData` in `examples/simpleDemo/main.go` gated inserts into both the `logs` and `users` collections on a single `logs.CountDocuments` check.
- If `logs.InsertMany` succeeded but `users.InsertMany` failed, the process would `log.Fatalf`, `docker-compose`'s `restart: unless-stopped` would respawn the container, and the restart would see `logs` already populated and skip seeding entirely — permanently leaving `users` empty.
- Each collection is now checked and seeded independently, so a partial failure can be retried without losing seeding for either collection.
- Flagged in review on #18: https://github.com/alexland23/gomongoapi/pull/18#issuecomment-5226538792

## Test plan
- [x] `go build ./...` (examples/simpleDemo module)
- [x] `go vet ./...` (examples/simpleDemo module)
- [ ] Manual: run `docker-compose up`, kill Mongo mid-seed to force partial failure, confirm restart completes seeding for both collections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qcmxCTv7DoXfXnTrKvrLj