### PR TITLE
Fix aggregate route silently ignoring lowercase "aggregate" body key

### DIFF
--- a/server.go
+++ b/server.go
@@ -58,6 +58,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
@@ -374,7 +375,7 @@ func (s *server) collectionCount(ctx *gin.Context) {
 
 // Runs an aggregate on the collection
 // /collections/:name/aggregate
-// Request body should contain the aggregate command
+// Request body should contain the aggregate command, the "aggregate" key is matched case-insensitively
 //	ex) Request Body: {"Aggregate": [{"$match": { "UserName": "Jon" }}]
 func (s *server) collectionAggregate(ctx *gin.Context) {
 
@@ -406,14 +407,21 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		return
 	}
 
-	// Get pipeline, if it doesn't exists an empty pipeline will be used
+	// Get pipeline, matching the "aggregate" key case-insensitively so callers
+	// sending lowercase JSON (the common case) aren't silently ignored. If no
+	// recognizable key is present, an empty pipeline will be used.
 	var pipeLine []any
-	if rawPipeline, ok := reqBody["Aggregate"]; ok {
+	for key, rawPipeline := range reqBody {
+		if !strings.EqualFold(key, "Aggregate") {
+			continue
+		}
+		var ok bool
 		pipeLine, ok = rawPipeline.([]any)
 		if !ok {
 			ctx.String(http.StatusBadRequest, "Aggregate field must be an array")
 			return
 		}
+		break
 	}
 
 	opts := options.Aggregate()

--- a/server_test.go
+++ b/server_test.go
@@ -651,6 +651,10 @@ func TestCollectionAggregate_NonArrayAggregateField(t *testing.T) {
 }
 
 func TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline(t *testing.T) {
+	// Deliberate behavior: a body with no recognizable pipeline field (under any
+	// casing of "aggregate") stays a 200 with an empty pipeline rather than a 400,
+	// so callers can intentionally fetch an entire small collection without
+	// constructing a no-op pipeline.
 	client := requireMongo(t)
 	dbName := testDBName(t)
 	ctx := context.Background()
@@ -669,6 +673,43 @@ func TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline(t *testing.T
 	var results []map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
 	assert.Len(t, results, 1)
+}
+
+func TestCollectionAggregate_LowercaseAggregateKeyIsApplied(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a", "qty": 1},
+		bson.M{"name": "a", "qty": 3},
+		bson.M{"name": "b", "qty": 5},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	body := `{"aggregate":[{"$match":{"name":"a"}},{"$group":{"_id":"$name","total":{"$sum":"$qty"}}}]}`
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 1)
+	assert.EqualValues(t, 4, results[0]["total"])
+}
+
+func TestCollectionAggregate_NonArrayLowercaseAggregateField(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"aggregate":"not-an-array"}`)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Aggregate field must be an array")
 }
 
 func TestCollectionAggregate_Success(t *testing.T) {

--- a/server_test.go
+++ b/server_test.go
@@ -3,6 +3,8 @@ package gomongoapi
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -100,12 +102,37 @@ func disconnectedClient(t *testing.T) *mongo.Client {
 	return client
 }
 
+// maxMongoDBNameLen is MongoDB's limit on database name length: names must
+// be fewer than 64 characters.
+const maxMongoDBNameLen = 63
+
 // testDBName derives a unique, valid Mongo database name from the current
 // test name so tests sharing the container don't collide with each other.
 func testDBName(t *testing.T) string {
 	t.Helper()
 	replacer := strings.NewReplacer("/", "_", " ", "_")
-	return "test_" + replacer.Replace(t.Name())
+	name := "test_" + replacer.Replace(t.Name())
+	if len(name) <= maxMongoDBNameLen {
+		return name
+	}
+
+	// Long test names (especially subtests) can exceed Mongo's database name
+	// limit. Truncate and append a short hash of the full name so distinct
+	// long names don't collide once truncated.
+	sum := sha1.Sum([]byte(name))
+	suffix := "_" + hex.EncodeToString(sum[:])[:8]
+	return name[:maxMongoDBNameLen-len(suffix)] + suffix
+}
+
+func TestTestDBName_StaysWithinMongoLimit(t *testing.T) {
+	shortName := testDBName(t)
+	assert.LessOrEqual(t, len(shortName), maxMongoDBNameLen)
+
+	t.Run("ThisIsADeliberatelyVeryLongSubtestNameChosenToExceedMongoDBsSixtyFourCharacterDatabaseNameLimitOnItsOwn", func(t *testing.T) {
+		longName := testDBName(t)
+		assert.LessOrEqual(t, len(longName), maxMongoDBNameLen)
+		assert.True(t, strings.HasPrefix(longName, "test_"))
+	})
 }
 
 // newTestServer builds a server directly (bypassing NewServer/Options) so


### PR DESCRIPTION
## Summary
- `collectionAggregate` matched the pipeline body key with an exact-case `"Aggregate"` lookup, so a body like `{"aggregate": [...]}` (lowercase, what most JSON clients and Grafana panels naturally send) was silently ignored and the route ran an unfiltered aggregate over the entire collection.
- The key is now matched case-insensitively via `strings.EqualFold`, so `Aggregate`/`aggregate`/any other casing all resolve to the same pipeline.
- The "no recognizable key at all → empty pipeline, 200 OK" behavior is kept, but now deliberately documented (in both the doc comment and the existing regression test) rather than left as an accident, per the issue's DoD.
- Also fixed a pre-existing test-infra bug found while validating this change: `testDBName` derived the test Mongo database name directly from `t.Name()`, and MongoDB rejects database names of 64+ characters. `TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline`'s name alone produced a 67-character database name, so it failed with `InvalidNamespace` on every run (confirmed on `main` before this branch's other changes). `testDBName` now truncates and appends a short hash when the generated name would exceed the limit, keeping long names valid and collision-resistant.

## Test plan
- [x] `TestCollectionAggregate_LowercaseAggregateKeyIsApplied` — new regression test asserting a lowercase `aggregate` key actually filters the pipeline
- [x] `TestCollectionAggregate_NonArrayLowercaseAggregateField` — new test asserting a non-array lowercase `aggregate` field still 400s
- [x] `TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline` — updated with a comment making the empty-pipeline fallback intentional; now passes (previously failed due to the `testDBName` bug above)
- [x] `TestTestDBName_StaysWithinMongoLimit` — new test asserting `testDBName` never exceeds Mongo's database name limit, including for long (sub)test names
- [x] `go vet ./...`, `go build ./...`, and `go test ./...` all pass cleanly

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qcmxCTv7DoXfXnTrKvrLj