### PR TITLE
Apply result limit to aggregate route

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,10 @@ Then open Grafana at http://localhost:3000 (default login `admin` / `admin`).
 | `/custom/<custom route>`              | GET       | N/A   | User-defined GET route — user controls everything.                                                     |
 | `/custom/<custom route>`              | POST      | N/A   | User-defined POST route — user controls everything.                                                    |
 
-`find` and `aggregate` both accept an optional `limit` url param, and `find` respects a
-server-wide max limit if one is configured (see [`Options`](#options) below).
+`find` and `aggregate` both accept an optional `limit` url param, and both respect a
+server-wide default (`FindLimit`) and max (`FindMaxLimit`) if configured (see
+[`Options`](#options) below). For `aggregate`, the limit is applied as a `$limit` stage
+appended to the end of the caller's pipeline.
 
 ## Options
 
@@ -91,8 +93,8 @@ be customized with the setter methods below before being passed to `gomongoapi.N
 | `CustomRouteName` / `SetCustomRouteName(string)`| `custom`             | Route group name used for custom routes. Cannot be `/` or `/api`.                               |
 | `MongoClientOpts` / `SetMongoClientOpts(*options.ClientOptions)` | empty options | MongoDB client options, e.g. connection URI. Required for a real connection.        |
 | `DefaultDB` / `SetDefaultDB(string)`            | none (unset)         | If set, all routes operate against this database and the `database` url param is not needed.    |
-| `FindLimit` / `SetFindLimit(int)`               | `1000`               | Default number of records returned by `find` when no `limit` url param is passed.               |
-| `FindMaxLimit` / `SetFindMaxLimit(int)`         | `0` (no limit)       | Upper bound on the `limit` url param for `find`. Requests above this are rejected.               |
+| `FindLimit` / `SetFindLimit(int)`               | `1000`               | Default number of records returned by `find` and `aggregate` when no `limit` url param is passed. |
+| `FindMaxLimit` / `SetFindMaxLimit(int)`         | `0` (no limit)       | Upper bound on the `limit` url param for `find` and `aggregate`. Requests above this are rejected. |
 
 ## Custom routes and middleware
 

--- a/server.go
+++ b/server.go
@@ -375,6 +375,7 @@ func (s *server) collectionCount(ctx *gin.Context) {
 
 // Runs an aggregate on the collection
 // /collections/:name/aggregate
+// Valid URL parameter are 'database' and 'limit'
 // Request body should contain the aggregate command, the "aggregate" key is matched case-insensitively
 //	ex) Request Body: {"Aggregate": [{"$match": { "UserName": "Jon" }}]
 func (s *server) collectionAggregate(ctx *gin.Context) {
@@ -399,9 +400,25 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		return
 	}
 
+	// Get limit, if none was passed default to default value
+	limitString := ctx.DefaultQuery("limit", s.findLimit)
+	limit, err := strconv.Atoi(limitString)
+	if err != nil {
+		ctx.String(http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
+		return
+	}
+
+	// If max limit is set, ensure passed limit is not greater than it.
+	if s.maxLimit != 0 {
+		if limit > s.maxLimit {
+			ctx.String(http.StatusBadRequest, "Passed limit is greater than max limit set by server")
+			return
+		}
+	}
+
 	// Get request body
 	var reqBody map[string]interface{}
-	err := ctx.ShouldBind(&reqBody)
+	err = ctx.ShouldBind(&reqBody)
 	if err != nil {
 		ctx.String(http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
@@ -423,6 +440,12 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		}
 		break
 	}
+
+	// Cap the result count by appending a trailing $limit stage. This is
+	// applied unconditionally, even if the caller's pipeline ends in a
+	// $group or $sort, since a final $limit bounds the result count
+	// regardless of what produced it.
+	pipeLine = append(pipeLine, bson.M{"$limit": limit})
 
 	opts := options.Aggregate()
 	opts.SetAllowDiskUse(true)

--- a/server_test.go
+++ b/server_test.go
@@ -729,6 +729,103 @@ func TestCollectionAggregate_LowercaseAggregateKeyIsApplied(t *testing.T) {
 	assert.EqualValues(t, 4, results[0]["total"])
 }
 
+func TestCollectionAggregate_BadLimit(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate?limit=notanumber", `{"Aggregate":[]}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCollectionAggregate_LimitExceedsMax(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 10)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate?limit=50", `{"Aggregate":[]}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCollectionAggregate_RespectsDefaultLimit(t *testing.T) {
+	// An empty pipeline would otherwise return the entire collection; the
+	// server-wide default limit must still cap it.
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	docs := make([]any, 0, 5)
+	for i := range 5 {
+		docs = append(docs, bson.M{"n": i})
+	}
+	_, err := coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 2, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"Aggregate":[]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 2)
+}
+
+func TestCollectionAggregate_RespectsLimitParam(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	docs := make([]any, 0, 5)
+	for i := range 5 {
+		docs = append(docs, bson.M{"n": i})
+	}
+	_, err := coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate?limit=3", `{"Aggregate":[]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 3)
+}
+
+func TestCollectionAggregate_LimitAppliedAfterGroupStage(t *testing.T) {
+	// Verifies the trailing $limit stage still caps results even when the
+	// caller's pipeline ends in a $group, which produces fewer documents
+	// than it consumed.
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a", "qty": 1},
+		bson.M{"name": "b", "qty": 2},
+		bson.M{"name": "c", "qty": 3},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 2, 0)
+	s.createRoutes()
+
+	body := `{"Aggregate":[{"$group":{"_id":"$name","total":{"$sum":"$qty"}}}]}`
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 2)
+}
+
 func TestCollectionAggregate_NonArrayLowercaseAggregateField(t *testing.T) {
 	s := newTestServer(nil, "app", 100, 0)
 	s.createRoutes()


### PR DESCRIPTION
## Summary

- `collectionAggregate` previously applied no result cap at all — an empty or broad pipeline (including via the lowercase-key typo fixed in #39) would return the entire collection.
- The route now honors an optional `limit` url param, mirroring `find`: defaults to `Options.FindLimit` when absent, rejected with 400 if it exceeds `Options.FindMaxLimit` (when a max is configured).
- The resolved limit is applied as a `bson.M{"$limit": limit}` stage appended unconditionally to the end of the caller's pipeline, including when the pipeline already ends in `$group`/`$sort` — a trailing `$limit` bounds the final result count regardless of what produced it.
- No new `AggregateLimit`/`SetAggregateLimit` option was added; `FindLimit`/`FindMaxLimit` are now the shared cap for both `find` and `aggregate`, matching what `README.md` already (incorrectly, until this PR) documented. Decision recorded on the issue: https://github.com/alexland23/gomongoapi/issues/21#issuecomment-5226761048
- `README.md` updated to describe the real (now correct) behavior.

This is a behavior change for existing `aggregate` callers relying on unbounded results — they'll now be capped at `FindLimit` (1000 by default) unless `SetFindLimit`/`SetFindMaxLimit` are configured otherwise. Worth a version bump note per the issue.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, including new container-backed tests)
- [x] New tests: bad `limit` param (400), `limit` exceeding `FindMaxLimit` (400), default `FindLimit` caps an otherwise-unbounded pipeline, `limit` url param is respected, `$limit` is still applied correctly after a `$group` stage

Fixes #21