### PR TITLE
find: clamp server-side default limit instead of rejecting it

### DIFF
--- a/server.go
+++ b/server.go
@@ -283,20 +283,28 @@ func (s *server) collectionFind(ctx *gin.Context) {
 		return
 	}
 
-	// Get limit, if none was passed default to default value
-	limitString := ctx.DefaultQuery("limit", s.findLimit)
+	// Get limit, if none was passed default to default value. Track whether the
+	// caller actually passed one so it can be distinguished from the server default below.
+	limitParam, limitPassed := ctx.GetQuery("limit")
+	limitString := limitParam
+	if !limitPassed {
+		limitString = s.findLimit
+	}
 	limit, err := strconv.Atoi(limitString)
 	if err != nil {
 		ctx.String(http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
 		return
 	}
 
-	// If max limit is set, ensure passed limit is not greater than it.
-	if s.maxLimit != 0 {
-		if limit > s.maxLimit {
+	// If max limit is set and the limit exceeds it: reject an explicit caller-supplied
+	// limit, but silently clamp the server-side default so FindMaxLimit < FindLimit
+	// doesn't break every request that omits "limit".
+	if s.maxLimit != 0 && limit > s.maxLimit {
+		if limitPassed {
 			ctx.String(http.StatusBadRequest, "Passed limit is greater than max limit set by server")
 			return
 		}
+		limit = s.maxLimit
 	}
 
 	// Get filter from request body

--- a/server.go
+++ b/server.go
@@ -408,20 +408,28 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		return
 	}
 
-	// Get limit, if none was passed default to default value
-	limitString := ctx.DefaultQuery("limit", s.findLimit)
+	// Get limit, if none was passed default to default value. Track whether the
+	// caller actually passed one so it can be distinguished from the server default below.
+	limitParam, limitPassed := ctx.GetQuery("limit")
+	limitString := limitParam
+	if !limitPassed {
+		limitString = s.findLimit
+	}
 	limit, err := strconv.Atoi(limitString)
 	if err != nil {
 		ctx.String(http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
 		return
 	}
 
-	// If max limit is set, ensure passed limit is not greater than it.
-	if s.maxLimit != 0 {
-		if limit > s.maxLimit {
+	// If max limit is set and the limit exceeds it: reject an explicit caller-supplied
+	// limit, but silently clamp the server-side default so FindMaxLimit < FindLimit
+	// doesn't break every request that omits "limit".
+	if s.maxLimit != 0 && limit > s.maxLimit {
+		if limitPassed {
 			ctx.String(http.StatusBadRequest, "Passed limit is greater than max limit set by server")
 			return
 		}
+		limit = s.maxLimit
 	}
 
 	// Get request body

--- a/server_test.go
+++ b/server_test.go
@@ -772,6 +772,33 @@ func TestCollectionAggregate_LimitExceedsMax(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestCollectionAggregate_DefaultLimitExceedsMax_Clamped(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	docs := make([]any, 0, 5)
+	for i := range 5 {
+		docs = append(docs, bson.M{"n": i})
+	}
+	_, err := coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	// findLimit (1000) exceeds maxLimit (2); a request with no explicit "limit"
+	// must succeed and be capped at maxLimit rather than 400ing.
+	s := newTestServer(client, dbName, 1000, 2)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"Aggregate":[]}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 2)
+}
+
 func TestCollectionAggregate_RespectsDefaultLimit(t *testing.T) {
 	// An empty pipeline would otherwise return the entire collection; the
 	// server-wide default limit must still cap it.

--- a/server_test.go
+++ b/server_test.go
@@ -498,6 +498,33 @@ func TestCollectionFind_LimitExceedsMax(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestCollectionFind_DefaultLimitExceedsMax_Clamped(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	docs := make([]any, 0, 5)
+	for i := range 5 {
+		docs = append(docs, bson.M{"n": i})
+	}
+	_, err := coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	// findLimit (1000) exceeds maxLimit (2); a request with no explicit "limit"
+	// must succeed and be capped at maxLimit rather than 400ing.
+	s := newTestServer(client, dbName, 1000, 2)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `{}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 2)
+}
+
 func TestCollectionFind_BadRequestBody(t *testing.T) {
 	s := newTestServer(nil, "app", 100, 0)
 	s.createRoutes()


### PR DESCRIPTION
## Summary
- `collectionFind` resolved `limit` with `ctx.DefaultQuery("limit", s.findLimit)`, which makes the server-side default indistinguishable from a caller-supplied value once it reaches the `maxLimit` check.
- If `FindMaxLimit` was set below `FindLimit`, every request that omitted `limit` was rejected with a 400 — even though the caller never asked for a limit that high.
- Now uses `ctx.GetQuery("limit")` to tell the two cases apart: an explicit caller-supplied limit that exceeds `FindMaxLimit` still 400s (unchanged), but an oversized server-side default is silently clamped to `FindMaxLimit`.
- `collectionAggregate` had the identical bug (same `ctx.DefaultQuery` pattern) and gets the same fix.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, container-backed tests included)
- [x] New regression test `TestCollectionFind_DefaultLimitExceedsMax_Clamped`: `FindLimit=1000`, `FindMaxLimit=2`, no `limit` param → 200, results capped at 2
- [x] New regression test `TestCollectionAggregate_DefaultLimitExceedsMax_Clamped`: same scenario for the aggregate route
- [x] Existing `TestCollectionFind_LimitExceedsMax` / `TestCollectionAggregate_LimitExceedsMax` still confirm an explicit oversized `limit` still 400s

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGy1ZkFq8uhmSW4eMT2BYc