### PR TITLE
CI: GitHub Actions running vet + test, plus the example module build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: vet + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.0"
+
+      - name: go vet
+        run: make vet
+
+      - name: go test
+        run: make test
+
+  example-build:
+    name: example module build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.0"
+
+      - name: go build (examples/simpleDemo)
+        working-directory: examples/simpleDemo
+        run: go build ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,16 @@ jobs:
       - name: go vet
         run: make vet
 
-      - name: go test
-        run: make test
+      - name: go test with coverage
+        run: make cover-html
+
+      - name: upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.out
+            coverage.html
 
   example-build:
     name: example module build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
             coverage.out
             coverage.html
 
+      - name: upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+
   example-build:
     name: example module build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,10 @@ jobs:
             coverage.out
             coverage.html
 
-      - name: upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
           fail_ci_if_error: false
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gomongoapi
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexland23/gomongoapi.svg)](https://pkg.go.dev/github.com/alexland23/gomongoapi)
+[![codecov](https://codecov.io/gh/alexland23/gomongoapi/branch/main/graph/badge.svg)](https://codecov.io/gh/alexland23/gomongoapi)
 
 `gomongoapi` is a pure Go package for standing up an HTTP server that exposes a MongoDB
 instance over a small set of REST routes. It was built to make it easy to point


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running on push (main) and PR
- `test` job: `make vet` then `make test` — Docker is available on GitHub-hosted runners, so the container-backed Mongo tests in `server_test.go` actually execute (they self-skip only when `sharedMongoErr` is set, e.g. no Docker)
- `example-build` job: `go build ./...` inside `examples/simpleDemo`, its own Go module that `go build ./...` at the repo root never touches — so the job fails if the example drifts/breaks
- Go version pinned to `1.25.0` to match `go.mod` (both the root module and `examples/simpleDemo`)

## Test plan
- [x] `go build ./...` at repo root
- [x] `go vet ./...` at repo root
- [x] `make test` locally (Docker-backed container tests pass)
- [x] `go build ./...` inside `examples/simpleDemo`
- [ ] Workflow runs green on this PR (verify in the Actions tab once opened)

Fixes #24