### PR TITLE
Doc accuracy: add missing /count row to package doc route table

### DIFF
--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ Available default routes:
 	| /api/databases                   |    GET    | Empty | Returns list of available databases, unless a default is set.                                        |
 	| /api/collections                 |    GET    | Empty | Returns a list collections to the default db or the one passed in url param.                         |
 	| /api/collections/:name/find      |    POST   | JSON  | Returns result of find on the collection name. DB is either default or one passed in url param.      |
+	| /api/collections/:name/count     |    POST   | JSON  | Returns count of documents in the collection name. DB is either default or one passed in url param.  |
 	| /api/collections/:name/aggregate |    POST   | JSON  | Returns result of aggregate on the collection name. DB is either default or one passed in url param. |
 	| /custom/<Custom Route>           |    GET    | N/A   | Users can create custom GET route, they control everything.                                          |
 	| /custom/<Custom Route>           |    POST   | N/A   | Users can create custom POST route, they control everything.                                         |


### PR DESCRIPTION
## Summary

Issue #27 flagged four doc-accuracy gaps. Investigating current `main` (which has moved
significantly since the issue was filed — #39, #40, #22, #23, #25 all landed after) showed
only one of the four is still an actual bug:

- **`server.go`'s godoc route table was missing `/count`** — fixed here. The route has
  existed since #12 and the README table already lists it; the godoc page is the first
  thing a prospective user reads, so this was still misleading.
- **README's "`find` and `aggregate` both accept `limit`" claim** — already accurate.
  `collectionAggregate` now reads `limit` and applies it as a `$limit` stage (#22/#40).
- **CLAUDE.md's nil-router claim** — already corrected (#23/#42): `NewServer` now skips
  building route groups when `Options.Router` is nil instead of panicking, and CLAUDE.md
  reflects that.
- **CLAUDE.md's limit-conversion claim** — already corrected (#25): the dead `findMaxLimit`
  string field was removed, and CLAUDE.md now correctly states only `FindLimit` is
  converted to a string.

So the only code change needed was adding the `/count` row to the table in `server.go`,
matching the fixed-width formatting of the surrounding rows (all rows verified at 160
chars).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (passes; container-backed tests run against local Docker)
- [x] Manually verified all package-doc table rows are still aligned (160 chars each)
- [x] Verified README and CLAUDE.md claims against current `server.go` behavior — no
      further changes needed there

Fixes #27