### PR TITLE
README: add a Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,63 @@ docker-compose up
 
 Then open Grafana at http://localhost:3000 (default login `admin` / `admin`).
 
+> **Not for production.** This demo runs `/api` with no auth middleware and Grafana on
+> the default `admin` / `admin` login, all published on the host network. It's shaped for
+> a quick local look, not as a template for a real deployment — see [Security](#security).
+
+## Security
+
+`gomongoapi` gives a caller direct, unauthenticated access to whatever Mongo credentials
+you configure it with. It has no built-in auth, and the API is **not read-only**:
+`aggregate` passes the caller-supplied pipeline straight to the driver with no stage
+filtering, so a pipeline containing `$out` or `$merge` can write to or overwrite
+collections, and `find`/`count` filters are passed through as-is, so operators like
+`$where` or `$function` can execute server-side JavaScript depending on your MongoDB
+version and configuration. Treat this as a query surface with write potential, not a
+read-only reporting endpoint, and take the following seriously before exposing it
+anywhere besides `localhost`.
+
+### Use a read-only Mongo user
+
+Point `MongoClientOpts` at a connection string scoped to a Mongo user with `read` (not
+`readWrite`) on only the databases you intend to expose. This is the control that
+actually stops `$out`/`$merge`/`$where` from doing damage — everything else here is
+defense in depth on top of it.
+
+### No built-in auth
+
+`gomongoapi` does not authenticate requests itself. Use `SetAPIMiddleware` to add your
+own check in front of every `/api` route, for example a shared API key:
+
+```go
+const apiKey = "replace-with-a-securely-generated-key" // load from env/secrets, don't hardcode
+
+server.SetAPIMiddleware(func(ctx *gin.Context) {
+	if ctx.GetHeader("X-API-Key") != apiKey {
+		ctx.AbortWithStatus(http.StatusUnauthorized)
+		return
+	}
+	ctx.Next()
+})
+```
+
+`SetCustomMiddleware` is the equivalent hook for the `/custom` route group; apply the
+same kind of check there if you add custom routes.
+
+### Network boundary
+
+Don't publish the server's port directly to the internet. Put it behind a reverse proxy
+(for TLS termination and a single controlled entry point) or keep it on a private
+network reachable only by the Grafana instance querying it — ideally both.
+
+### Rate limiting
+
+`gomongoapi` doesn't ship any rate limiting. If the server is reachable by more than a
+trusted internal caller, add a rate-limiting gin middleware (e.g.
+[`ulule/limiter`](https://github.com/ulule/limiter) or
+[`gin-contrib/timeout`](https://github.com/gin-contrib/timeout)-style approaches) via
+`SetAPIMiddleware`.
+
 ## Default routes
 
 | Path                                | HTTP Verb | Body  | Result                                                                                                |

--- a/examples/simpleDemo/docker-compose.yml
+++ b/examples/simpleDemo/docker-compose.yml
@@ -1,3 +1,7 @@
+# Demo only — not for production. No auth on the gomongoapi /api routes, Grafana runs
+# with its default admin/admin login, and every service is published on the host network.
+# See the "Security" section of the root README before deploying anything like this.
+
 volumes:
   mongodb-data:
   mongodb-config-data:


### PR DESCRIPTION
## Summary
- Adds a **Security** section to `README.md` covering: using a read-only Mongo user (the load-bearing control against `$out`/`$merge`/`$where`/`$function`), a worked `SetAPIMiddleware` API-key example since there's no built-in auth, the network boundary (reverse proxy / private network), and a pointer to gin rate-limiting middleware.
- Adds a "not for production" callout to the README right where the demo is introduced, and a matching comment at the top of `examples/simpleDemo/docker-compose.yml`, so the demo's shape (no auth, Grafana admin/admin, everything published) isn't mistaken for a deployment template.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Docs-only change (README + compose comment) — no Go source touched, so `go test ./...` behavior is unaffected
- [x] Manually reviewed the rendered README section for accuracy against `server.go`'s `aggregate`/`find`/`count` handlers

Fixes #28