### PR TITLE
Graceful shutdown: own http.Server, signal handling, context timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ func main() {
 	// Create server
 	server := gomongoapi.NewServer(serverOpts)
 
-	// Start server, blocks until an error occurs
+	// Start server, blocks until SIGINT/SIGTERM triggers a graceful shutdown
+	// or an error occurs
 	log.Fatal(server.Start())
 }
 ```

--- a/examples/simpleDemo/main.go
+++ b/examples/simpleDemo/main.go
@@ -60,7 +60,8 @@ func main() {
 		ctx.JSON(http.StatusOK, bson.M{"Count": count})
 	})
 
-	// Start server, blocks until an error occurs
+	// Start server, blocks until SIGINT/SIGTERM triggers a graceful shutdown
+	// or an error occurs
 	log.Fatal(server.Start())
 }
 

--- a/option.go
+++ b/option.go
@@ -2,6 +2,7 @@ package gomongoapi
 
 import (
 	"errors"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/mongo/options"
@@ -32,17 +33,32 @@ type Options struct {
 
 	// Optional field if user wants to set a default database to use. If none is set then all databases will be queryable.
 	DefaultDB string
+
+	// Upper bound on the initial Mongo Connect+Ping during Start(), so a hung Mongo host can't
+	// block startup indefinitely. Default is 10 seconds.
+	ConnectTimeout time.Duration
+
+	// Upper bound on each of the graceful HTTP shutdown and the subsequent Mongo disconnect when
+	// Start() receives SIGINT/SIGTERM. Default is 10 seconds.
+	ShutdownTimeout time.Duration
+
+	// Upper bound on how long the HTTP server waits to read a request's headers, guarding against
+	// slow-header (Slowloris) attacks. Default is 5 seconds.
+	ReadHeaderTimeout time.Duration
 }
 
 // ServerOptions returns server options with default values.
 func ServerOptions() *Options {
 	return &Options{
-		Router:          gin.Default(),
-		Address:         ":8080",
-		CustomRouteName: "custom",
-		MongoClientOpts: options.Client(),
-		FindLimit:       1000,
-		FindMaxLimit:    0,
+		Router:            gin.Default(),
+		Address:           ":8080",
+		CustomRouteName:   "custom",
+		MongoClientOpts:   options.Client(),
+		FindLimit:         1000,
+		FindMaxLimit:      0,
+		ConnectTimeout:    defaultConnectTimeout,
+		ShutdownTimeout:   defaultShutdownTimeout,
+		ReadHeaderTimeout: defaultReadHeaderTimeout,
 	}
 }
 
@@ -86,4 +102,21 @@ func (o *Options) SetFindLimit(findLimit int) {
 // SetFindMaxLimit sets the upper limit for find results.
 func (o *Options) SetFindMaxLimit(findMaxLimit int) {
 	o.FindMaxLimit = findMaxLimit
+}
+
+// SetConnectTimeout sets the upper bound on the initial Mongo Connect+Ping during Start().
+func (o *Options) SetConnectTimeout(connectTimeout time.Duration) {
+	o.ConnectTimeout = connectTimeout
+}
+
+// SetShutdownTimeout sets the upper bound on each of the graceful HTTP shutdown and the
+// subsequent Mongo disconnect when Start() receives SIGINT/SIGTERM.
+func (o *Options) SetShutdownTimeout(shutdownTimeout time.Duration) {
+	o.ShutdownTimeout = shutdownTimeout
+}
+
+// SetReadHeaderTimeout sets the upper bound on how long the HTTP server waits to read a
+// request's headers.
+func (o *Options) SetReadHeaderTimeout(readHeaderTimeout time.Duration) {
+	o.ReadHeaderTimeout = readHeaderTimeout
 }

--- a/option_test.go
+++ b/option_test.go
@@ -2,6 +2,7 @@ package gomongoapi
 
 import (
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,9 @@ func TestServerOptionsDefaults(t *testing.T) {
 	assert.Equal(t, 1000, opts.FindLimit)
 	assert.Equal(t, 0, opts.FindMaxLimit)
 	assert.Equal(t, "", opts.DefaultDB)
+	assert.Equal(t, 10*time.Second, opts.ConnectTimeout)
+	assert.Equal(t, 10*time.Second, opts.ShutdownTimeout)
+	assert.Equal(t, 5*time.Second, opts.ReadHeaderTimeout)
 }
 
 func TestSetRouter(t *testing.T) {
@@ -100,4 +104,28 @@ func TestSetFindMaxLimit(t *testing.T) {
 	opts.SetFindMaxLimit(2000)
 
 	assert.Equal(t, 2000, opts.FindMaxLimit)
+}
+
+func TestSetConnectTimeout(t *testing.T) {
+	opts := ServerOptions()
+
+	opts.SetConnectTimeout(30 * time.Second)
+
+	assert.Equal(t, 30*time.Second, opts.ConnectTimeout)
+}
+
+func TestSetShutdownTimeout(t *testing.T) {
+	opts := ServerOptions()
+
+	opts.SetShutdownTimeout(30 * time.Second)
+
+	assert.Equal(t, 30*time.Second, opts.ShutdownTimeout)
+}
+
+func TestSetReadHeaderTimeout(t *testing.T) {
+	opts := ServerOptions()
+
+	opts.SetReadHeaderTimeout(15 * time.Second)
+
+	assert.Equal(t, 15*time.Second, opts.ReadHeaderTimeout)
 }

--- a/server.go
+++ b/server.go
@@ -82,6 +82,10 @@ const defaultConnectTimeout = 10 * time.Second
 // signal is received.
 const defaultShutdownTimeout = 10 * time.Second
 
+// readHeaderTimeout bounds how long the HTTP server waits to read a
+// request's headers, guarding against slow-header (Slowloris) attacks.
+const readHeaderTimeout = 5 * time.Second
+
 // Server interface for mongo api server
 type Server interface {
 
@@ -202,8 +206,9 @@ func (s *server) Start() error {
 	s.createRoutes()
 
 	httpServer := &http.Server{
-		Addr:    s.address,
-		Handler: s.router,
+		Addr:              s.address,
+		Handler:           s.router,
+		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
 	// Listen for SIGINT/SIGTERM so a normal `docker stop`/`kubectl delete

--- a/server.go
+++ b/server.go
@@ -22,7 +22,7 @@ Available default routes:
 
 To use the package, user must create the server options and at the minimum set the mongodb client options to connect to
 the db. Once the options are made, they can be passed to create a new server. Server Start() function will run the server
-and block until it encounters an error.
+and block until a SIGINT/SIGTERM is received or it encounters an error, gracefully shutting down before returning.
 
 Example
 
@@ -56,11 +56,15 @@ package gomongoapi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"os/signal"
 	"strconv"
 	"strings"
+	"syscall"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"go.mongodb.org/mongo-driver/bson"
@@ -68,11 +72,23 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// defaultConnectTimeout bounds how long Start waits for the initial Mongo
+// Connect+Ping before giving up, so a hung Mongo host can't block startup
+// indefinitely.
+const defaultConnectTimeout = 10 * time.Second
+
+// defaultShutdownTimeout bounds how long graceful HTTP shutdown and the
+// subsequent Mongo disconnect are each allowed to take once a shutdown
+// signal is received.
+const defaultShutdownTimeout = 10 * time.Second
+
 // Server interface for mongo api server
 type Server interface {
 
 	// Start new server
-	// This function will block unless an error occurs
+	// This function blocks until a SIGINT/SIGTERM is received or an error
+	// occurs, at which point it shuts down the HTTP server and disconnects
+	// from MongoDB before returning.
 	Start() error
 
 	// Add custom middleware in the /api router group.
@@ -108,6 +124,11 @@ type server struct {
 	defaultDB       string
 	findLimit       string
 	maxLimit        int
+
+	// Timeouts for startup and shutdown. Set to the default* constants by
+	// NewServer; tests construct a *server directly to override them.
+	connectTimeout  time.Duration
+	shutdownTimeout time.Duration
 }
 
 // NewServer creates a new server. Must pass in Mongo Client Options.
@@ -135,28 +156,39 @@ func NewServer(opts *Options) Server {
 		defaultDB:       opts.DefaultDB,
 		findLimit:       findLimit,
 		maxLimit:        opts.FindMaxLimit,
+		connectTimeout:  defaultConnectTimeout,
+		shutdownTimeout: defaultShutdownTimeout,
 	}
 }
 
 // Start new server
-// This function will block unless an error occurs
+// This function blocks until a SIGINT/SIGTERM is received or an error
+// occurs, at which point it shuts down the HTTP server and disconnects
+// from MongoDB before returning.
 func (s *server) Start() error {
+
+	// Bound the initial Connect+Ping so a hung Mongo host can't block
+	// startup indefinitely.
+	connectCtx, cancel := context.WithTimeout(context.Background(), s.connectTimeout)
+	defer cancel()
 
 	var err error
 
 	// Create MongoDB Connection
-	s.mongoClient, err = mongo.Connect(context.TODO(), s.mongoClientOpts)
+	s.mongoClient, err = mongo.Connect(connectCtx, s.mongoClientOpts)
 	if err != nil {
 		return err
 	}
 	defer func() {
-		if err = s.mongoClient.Disconnect(context.TODO()); err != nil {
-			log.Printf("Error while disconnecting from MongoDB: %s\n", err.Error())
+		disconnectCtx, disconnectCancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+		defer disconnectCancel()
+		if disconnectErr := s.mongoClient.Disconnect(disconnectCtx); disconnectErr != nil {
+			log.Printf("Error while disconnecting from MongoDB: %s\n", disconnectErr.Error())
 		}
 	}()
 
 	// Test the connection
-	err = s.mongoClient.Ping(context.TODO(), nil)
+	err = s.mongoClient.Ping(connectCtx, nil)
 	if err != nil {
 		return err
 	}
@@ -169,10 +201,39 @@ func (s *server) Start() error {
 	// Set routes
 	s.createRoutes()
 
-	// Start router, this will block until error occurs
-	err = s.router.Run(s.address)
+	httpServer := &http.Server{
+		Addr:    s.address,
+		Handler: s.router,
+	}
 
-	return err
+	// Listen for SIGINT/SIGTERM so a normal `docker stop`/`kubectl delete
+	// pod` triggers the graceful shutdown below instead of killing the
+	// process before the deferred Mongo disconnect above can run.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	serveErrCh := make(chan error, 1)
+	go func() {
+		if serveErr := httpServer.ListenAndServe(); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			serveErrCh <- serveErr
+			return
+		}
+		serveErrCh <- nil
+	}()
+
+	// Block until either a shutdown signal arrives or the listener itself
+	// fails (e.g. address already in use); a listener failure has nothing
+	// left to gracefully shut down, so it's returned immediately.
+	select {
+	case <-ctx.Done():
+	case err = <-serveErrCh:
+		return err
+	}
+
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), s.shutdownTimeout)
+	defer shutdownCancel()
+
+	return httpServer.Shutdown(shutdownCtx)
 }
 
 // Sets the routes based on the mongo connection db and collections

--- a/server.go
+++ b/server.go
@@ -82,9 +82,9 @@ const defaultConnectTimeout = 10 * time.Second
 // signal is received.
 const defaultShutdownTimeout = 10 * time.Second
 
-// readHeaderTimeout bounds how long the HTTP server waits to read a
+// defaultReadHeaderTimeout bounds how long the HTTP server waits to read a
 // request's headers, guarding against slow-header (Slowloris) attacks.
-const readHeaderTimeout = 5 * time.Second
+const defaultReadHeaderTimeout = 5 * time.Second
 
 // Server interface for mongo api server
 type Server interface {
@@ -129,10 +129,11 @@ type server struct {
 	findLimit       string
 	maxLimit        int
 
-	// Timeouts for startup and shutdown. Set to the default* constants by
+	// Timeouts for startup and shutdown. Populated from Options by
 	// NewServer; tests construct a *server directly to override them.
-	connectTimeout  time.Duration
-	shutdownTimeout time.Duration
+	connectTimeout    time.Duration
+	shutdownTimeout   time.Duration
+	readHeaderTimeout time.Duration
 }
 
 // NewServer creates a new server. Must pass in Mongo Client Options.
@@ -152,16 +153,17 @@ func NewServer(opts *Options) Server {
 	findLimit := strconv.Itoa(opts.FindLimit)
 
 	return &server{
-		mongoClientOpts: opts.MongoClientOpts,
-		router:          router,
-		apiRouter:       apiRouter,
-		customRouter:    customRouter,
-		address:         opts.Address,
-		defaultDB:       opts.DefaultDB,
-		findLimit:       findLimit,
-		maxLimit:        opts.FindMaxLimit,
-		connectTimeout:  defaultConnectTimeout,
-		shutdownTimeout: defaultShutdownTimeout,
+		mongoClientOpts:   opts.MongoClientOpts,
+		router:            router,
+		apiRouter:         apiRouter,
+		customRouter:      customRouter,
+		address:           opts.Address,
+		defaultDB:         opts.DefaultDB,
+		findLimit:         findLimit,
+		maxLimit:          opts.FindMaxLimit,
+		connectTimeout:    opts.ConnectTimeout,
+		shutdownTimeout:   opts.ShutdownTimeout,
+		readHeaderTimeout: opts.ReadHeaderTimeout,
 	}
 }
 
@@ -208,7 +210,7 @@ func (s *server) Start() error {
 	httpServer := &http.Server{
 		Addr:              s.address,
 		Handler:           s.router,
-		ReadHeaderTimeout: readHeaderTimeout,
+		ReadHeaderTimeout: s.readHeaderTimeout,
 	}
 
 	// Listen for SIGINT/SIGTERM so a normal `docker stop`/`kubectl delete

--- a/server_test.go
+++ b/server_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -336,9 +337,8 @@ func TestStart_Success(t *testing.T) {
 
 	errCh := make(chan error, 1)
 	go func() {
-		// Start() blocks serving HTTP until an error occurs; there's no
-		// graceful-shutdown hook on the Server interface, so this goroutine
-		// is intentionally left running for the rest of the test binary.
+		// Start() blocks serving HTTP until a shutdown signal arrives or an
+		// error occurs.
 		errCh <- srv.Start()
 	}()
 
@@ -350,6 +350,81 @@ func TestStart_Success(t *testing.T) {
 		require.NotNil(t, client)
 		assert.NoError(t, client.Ping(context.Background(), nil))
 	}
+
+	// Signal the running server so its goroutine doesn't outlive the test;
+	// TestStart_GracefulShutdown covers the shutdown behavior itself.
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start() did not return after SIGTERM")
+	}
+}
+
+func TestStart_GracefulShutdown(t *testing.T) {
+	requireMongo(t)
+
+	opts := ServerOptions()
+	opts.SetMongoClientOpts(options.Client().ApplyURI(sharedMongoURI))
+	opts.SetAddress("127.0.0.1:0")
+
+	srv := NewServer(opts)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- srv.Start()
+	}()
+
+	// Give Start() time to connect, register its SIGTERM handler, and start
+	// serving before signalling shutdown.
+	select {
+	case err := <-errCh:
+		t.Fatalf("Start() returned before shutdown was requested: %v", err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	client := srv.GetMongoClient()
+	require.NotNil(t, client)
+	require.NoError(t, client.Ping(context.Background(), nil))
+
+	require.NoError(t, syscall.Kill(syscall.Getpid(), syscall.SIGTERM))
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "Start() should return nil after a graceful shutdown")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start() did not return after SIGTERM")
+	}
+
+	// The deferred Mongo disconnect should have run as part of shutdown.
+	assert.Error(t, client.Ping(context.Background(), nil))
+}
+
+func TestStart_ConnectTimeout(t *testing.T) {
+	// 192.0.2.0/24 is reserved for documentation (RFC 5737) and never
+	// responds, so Connect/Ping only return once our own connectTimeout
+	// fires rather than because of a connection refusal.
+	opts := ServerOptions()
+	opts.SetMongoClientOpts(
+		options.Client().
+			ApplyURI("mongodb://192.0.2.1:27017").
+			SetServerSelectionTimeout(30 * time.Second).
+			SetConnectTimeout(30 * time.Second),
+	)
+
+	srv, ok := NewServer(opts).(*server)
+	require.True(t, ok)
+	srv.connectTimeout = 300 * time.Millisecond
+	srv.shutdownTimeout = defaultShutdownTimeout
+
+	start := time.Now()
+	err := srv.Start()
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Less(t, elapsed, 5*time.Second, "Start() should have aborted via connectTimeout, not the driver's own 30s timeout")
 }
 
 // ---- getDatabases ----

--- a/server_test.go
+++ b/server_test.go
@@ -174,6 +174,9 @@ func TestNewServer(t *testing.T) {
 	opts.SetDefaultDB("app")
 	opts.SetFindLimit(50)
 	opts.SetFindMaxLimit(500)
+	opts.SetConnectTimeout(20 * time.Second)
+	opts.SetShutdownTimeout(15 * time.Second)
+	opts.SetReadHeaderTimeout(3 * time.Second)
 	require.NoError(t, opts.SetCustomRouteName("myroutes"))
 
 	srv := NewServer(opts)
@@ -188,6 +191,9 @@ func TestNewServer(t *testing.T) {
 	assert.Equal(t, "app", s.defaultDB)
 	assert.Equal(t, "50", s.findLimit)
 	assert.Equal(t, 500, s.maxLimit)
+	assert.Equal(t, 20*time.Second, s.connectTimeout)
+	assert.Equal(t, 15*time.Second, s.shutdownTimeout)
+	assert.Equal(t, 3*time.Second, s.readHeaderTimeout)
 	require.NotNil(t, s.apiRouter)
 	require.NotNil(t, s.customRouter)
 	assert.Equal(t, "/api", s.apiRouter.BasePath())
@@ -413,18 +419,16 @@ func TestStart_ConnectTimeout(t *testing.T) {
 			SetServerSelectionTimeout(30 * time.Second).
 			SetConnectTimeout(30 * time.Second),
 	)
+	opts.SetConnectTimeout(300 * time.Millisecond)
 
-	srv, ok := NewServer(opts).(*server)
-	require.True(t, ok)
-	srv.connectTimeout = 300 * time.Millisecond
-	srv.shutdownTimeout = defaultShutdownTimeout
+	srv := NewServer(opts)
 
 	start := time.Now()
 	err := srv.Start()
 	elapsed := time.Since(start)
 
 	require.Error(t, err)
-	assert.Less(t, elapsed, 5*time.Second, "Start() should have aborted via connectTimeout, not the driver's own 30s timeout")
+	assert.Less(t, elapsed, 5*time.Second, "Start() should have aborted via Options.ConnectTimeout, not the driver's own 30s timeout")
 }
 
 // ---- getDatabases ----


### PR DESCRIPTION
## Summary
- `Start()` now runs its own `http.Server` instead of `gin.Engine.Run`, and listens for `SIGINT`/`SIGTERM` via `signal.NotifyContext`. On shutdown it calls `http.Server.Shutdown(ctx)` followed by `mongoClient.Disconnect(ctx)`, so the normal `docker stop`/`kubectl delete pod` path now drains in-flight requests and cleanly disconnects from Mongo instead of the process being killed mid-flight.
- The initial Mongo `Connect`+`Ping` is now bounded by a timeout (`context.WithTimeout` instead of `context.TODO()`), so a hung Mongo host can no longer block startup indefinitely.
- The `http.Server` sets `ReadHeaderTimeout` (gosec G112: Slowloris protection).
- All three timeouts — `ConnectTimeout`, `ShutdownTimeout`, `ReadHeaderTimeout` — are exposed as `Options` fields with `SetConnectTimeout`/`SetShutdownTimeout`/`SetReadHeaderTimeout` setters, following the existing `SetFindLimit`/`SetFindMaxLimit` pattern, so consumers can tune them for their own network/deployment characteristics. `ServerOptions()` defaults them to 10s/10s/5s.
- `Start()` keeps its current blocking signature (per the issue's open question) rather than adding a separate `Shutdown()` to the `Server` interface.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` (0 issues)
- [x] `go test ./...` (Mongo-backed via testcontainers; ran locally with Docker available)
- [x] New `TestStart_GracefulShutdown`: sends a real `SIGTERM` to the test process and asserts `Start()` returns `nil` and the Mongo client is disconnected afterward
- [x] New `TestStart_ConnectTimeout`: points at an RFC 5737 documentation address (never responds) with `Options.SetConnectTimeout` set short, and asserts `Start()` aborts well before the driver's own 30s timeout would
- [x] `TestNewServer` asserts the new timeout fields propagate from `Options` into the server
- [x] New `option_test.go` coverage for `ServerOptionsDefaults` and each new setter
- [x] Updated `TestStart_Success` to cleanly signal shutdown at the end instead of leaking a goroutine for the rest of the test binary

Fixes #29