### PR TITLE
JSON error envelope on all failure paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project are documented here. Format loosely follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
+- **Breaking:** All `/api/...` route failure responses now return a JSON envelope,
+  `{"error": "<message>"}`, instead of a plain-text body. The status code for each
+  failure case is unchanged; only the response body format changed. Consumers that
+  matched on the previous plain-text error body will need to switch to parsing the
+  `error` field of the JSON body instead. Targeted for the `v1.1.0` release. (#31)

--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ server-wide default (`FindLimit`) and max (`FindMaxLimit`) if configured (see
 [`Options`](#options) below). For `aggregate`, the limit is applied as a `$limit` stage
 appended to the end of the caller's pipeline.
 
+### Error responses
+
+Every `/api/...` route returns a JSON envelope on failure, `{"error": "<message>"}`,
+with a non-2xx status code — for example a missing `database` param on
+`/api/collections` returns `400` with body `{"error": "Database name was not passed, one is needed"}`.
+This applies to validation errors (bad input) as well as errors surfaced from MongoDB
+itself (e.g. connection failures). See [CHANGELOG.md](CHANGELOG.md) for the release this
+landed in — earlier versions returned a plain-text body instead.
+
 ## Options
 
 `gomongoapi.ServerOptions()` returns an `*Options` populated with defaults, which can then
@@ -173,7 +182,7 @@ server.AddCustomGET("/appUsersCount", func(ctx *gin.Context) {
 
 	count, err := client.Database("app").Collection("users").CountDocuments(ctx.Request.Context(), bson.M{})
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error running count: "+err.Error())
+		ctx.JSON(http.StatusInternalServerError, bson.M{"error": "Error running count: " + err.Error()})
 		return
 	}
 

--- a/server.go
+++ b/server.go
@@ -42,7 +42,7 @@ Example
 
 		count, err := client.Database("app").Collection("users").CountDocuments(ctx.Request.Context(), bson.M{})
 		if err != nil {
-			ctx.String(http.StatusInternalServerError, "Error running count: "+err.Error())
+			ctx.JSON(http.StatusInternalServerError, bson.M{"error": "Error running count: " + err.Error()})
 			return
 		}
 
@@ -286,7 +286,7 @@ func (s *server) getDatabases(c *gin.Context) {
 
 	dbNames, err := s.mongoClient.ListDatabaseNames(c.Request.Context(), bson.M{})
 	if err != nil {
-		c.String(http.StatusInternalServerError, "Error getting databases names: %s", err.Error())
+		writeError(c, http.StatusInternalServerError, fmt.Sprintf("Error getting databases names: %s", err.Error()))
 		return
 	}
 
@@ -295,6 +295,13 @@ func (s *server) getDatabases(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, res)
+}
+
+// writeError writes a {"error": "<message>"} JSON envelope with the given
+// status code. All handler failure paths use this instead of ctx.String so
+// error responses are consistently JSON, matching the JSON success responses.
+func writeError(ctx *gin.Context, status int, message string) {
+	ctx.JSON(status, bson.M{"error": message})
 }
 
 // resolveDB determines the target database for a /api/collections/... route:
@@ -308,7 +315,7 @@ func (s *server) resolveDB(ctx *gin.Context) (dbName string, ok bool) {
 
 	dbName, ok = ctx.GetQuery("database")
 	if !ok {
-		ctx.String(http.StatusBadRequest, "Database name was not passed, one is needed")
+		writeError(ctx, http.StatusBadRequest, "Database name was not passed, one is needed")
 		return "", false
 	}
 	return dbName, true
@@ -325,7 +332,7 @@ func (s *server) getCollections(c *gin.Context) {
 
 	collNames, err := s.mongoClient.Database(dbName).ListCollectionNames(c.Request.Context(), bson.M{})
 	if err != nil {
-		c.String(http.StatusInternalServerError, "Error getting collection names: %s", err.Error())
+		writeError(c, http.StatusInternalServerError, fmt.Sprintf("Error getting collection names: %s", err.Error()))
 		return
 	}
 
@@ -351,7 +358,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	// Get collection name, return error if one isn't passed
 	collName := ctx.Param("name")
 	if collName == "" {
-		ctx.String(http.StatusBadRequest, "Collection name was not passed")
+		writeError(ctx, http.StatusBadRequest, "Collection name was not passed")
 		return
 	}
 
@@ -364,7 +371,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	}
 	limit, err := strconv.Atoi(limitString)
 	if err != nil {
-		ctx.String(http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
+		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
 		return
 	}
 
@@ -373,7 +380,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	// doesn't break every request that omits "limit".
 	if s.maxLimit != 0 && limit > s.maxLimit {
 		if limitPassed {
-			ctx.String(http.StatusBadRequest, "Passed limit is greater than max limit set by server")
+			writeError(ctx, http.StatusBadRequest, "Passed limit is greater than max limit set by server")
 			return
 		}
 		limit = s.maxLimit
@@ -383,7 +390,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	var filter bson.M
 	err = ctx.ShouldBindJSON(&filter)
 	if err != nil {
-		ctx.String(http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
+		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
 	}
 
@@ -394,7 +401,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	// Run find
 	cursor, err := s.mongoClient.Database(dbName).Collection(collName).Find(ctx.Request.Context(), filter, opts)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error running find: %s", err.Error())
+		writeError(ctx, http.StatusInternalServerError, fmt.Sprintf("Error running find: %s", err.Error()))
 		return
 	}
 
@@ -402,7 +409,7 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	var res []map[string]any
 	err = cursor.All(ctx.Request.Context(), &res)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error decoding results: %s", err.Error())
+		writeError(ctx, http.StatusInternalServerError, fmt.Sprintf("Error decoding results: %s", err.Error()))
 		return
 	}
 
@@ -424,7 +431,7 @@ func (s *server) collectionCount(ctx *gin.Context) {
 	// Get collection name, return error if one isn't passed
 	collName := ctx.Param("name")
 	if collName == "" {
-		ctx.String(http.StatusBadRequest, "Collection name was not passed")
+		writeError(ctx, http.StatusBadRequest, "Collection name was not passed")
 		return
 	}
 
@@ -432,14 +439,14 @@ func (s *server) collectionCount(ctx *gin.Context) {
 	var filter bson.M
 	err := ctx.ShouldBindJSON(&filter)
 	if err != nil {
-		ctx.String(http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
+		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
 	}
 
 	// Run find
 	count, err := s.mongoClient.Database(dbName).Collection(collName).CountDocuments(ctx.Request.Context(), filter)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error running find: %s", err.Error())
+		writeError(ctx, http.StatusInternalServerError, fmt.Sprintf("Error running find: %s", err.Error()))
 		return
 	}
 
@@ -462,7 +469,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 	// Get collection name, return error if one isn't passed
 	collName := ctx.Param("name")
 	if collName == "" {
-		ctx.String(http.StatusBadRequest, "Collection name was not passed")
+		writeError(ctx, http.StatusBadRequest, "Collection name was not passed")
 		return
 	}
 
@@ -475,7 +482,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 	}
 	limit, err := strconv.Atoi(limitString)
 	if err != nil {
-		ctx.String(http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
+		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Limit is not an int: %s", err.Error()))
 		return
 	}
 
@@ -484,7 +491,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 	// doesn't break every request that omits "limit".
 	if s.maxLimit != 0 && limit > s.maxLimit {
 		if limitPassed {
-			ctx.String(http.StatusBadRequest, "Passed limit is greater than max limit set by server")
+			writeError(ctx, http.StatusBadRequest, "Passed limit is greater than max limit set by server")
 			return
 		}
 		limit = s.maxLimit
@@ -494,7 +501,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 	var reqBody map[string]any
 	err = ctx.ShouldBind(&reqBody)
 	if err != nil {
-		ctx.String(http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
+		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
 	}
 
@@ -509,7 +516,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		var ok bool
 		pipeLine, ok = rawPipeline.([]any)
 		if !ok {
-			ctx.String(http.StatusBadRequest, "Aggregate field must be an array")
+			writeError(ctx, http.StatusBadRequest, "Aggregate field must be an array")
 			return
 		}
 		break
@@ -526,7 +533,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 
 	cursor, err := s.mongoClient.Database(dbName).Collection(collName).Aggregate(ctx.Request.Context(), pipeLine, opts)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error running aggregate: %s", err.Error())
+		writeError(ctx, http.StatusInternalServerError, fmt.Sprintf("Error running aggregate: %s", err.Error()))
 		return
 	}
 
@@ -534,7 +541,7 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 	var res []map[string]any
 	err = cursor.All(ctx.Request.Context(), &res)
 	if err != nil {
-		ctx.String(http.StatusInternalServerError, "Error decoding results: %s", err.Error())
+		writeError(ctx, http.StatusInternalServerError, fmt.Sprintf("Error decoding results: %s", err.Error()))
 		return
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -166,6 +166,22 @@ func doJSONRequest(router http.Handler, method, path, body string) *httptest.Res
 	return w
 }
 
+// errorBody decodes a handler failure response as the {"error": "..."} JSON
+// envelope and returns the message, failing the test if the body isn't in
+// that shape.
+func errorBody(t *testing.T, w *httptest.ResponseRecorder) string {
+	t.Helper()
+
+	assert.Equal(t, "application/json; charset=utf-8", w.Header().Get("Content-Type"))
+
+	var body struct {
+		Error string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.NotEmpty(t, body.Error)
+	return body.Error
+}
+
 // ---- NewServer ----
 
 func TestNewServer(t *testing.T) {
@@ -482,6 +498,7 @@ func TestGetDatabases_MongoError(t *testing.T) {
 	s.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error getting databases names")
 }
 
 // ---- getCollections ----
@@ -495,6 +512,7 @@ func TestGetCollections_MissingDatabaseParam(t *testing.T) {
 	s.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Database name was not passed, one is needed", errorBody(t, w))
 }
 
 func TestGetCollections_UsesDefaultDB(t *testing.T) {
@@ -554,6 +572,7 @@ func TestGetCollections_MongoError(t *testing.T) {
 	s.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error getting collection names")
 }
 
 // ---- collectionFind ----
@@ -564,6 +583,7 @@ func TestCollectionFind_MissingDatabaseParam(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `{}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Database name was not passed, one is needed", errorBody(t, w))
 }
 
 func TestCollectionFind_MissingCollectionName(t *testing.T) {
@@ -578,7 +598,7 @@ func TestCollectionFind_MissingCollectionName(t *testing.T) {
 	s.collectionFind(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Collection name was not passed")
+	assert.Equal(t, "Collection name was not passed", errorBody(t, w))
 }
 
 func TestCollectionFind_BadLimit(t *testing.T) {
@@ -587,6 +607,7 @@ func TestCollectionFind_BadLimit(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find?limit=notanumber", `{}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Limit is not an int")
 }
 
 func TestCollectionFind_LimitExceedsMax(t *testing.T) {
@@ -595,6 +616,7 @@ func TestCollectionFind_LimitExceedsMax(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find?limit=50", `{}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Passed limit is greater than max limit set by server", errorBody(t, w))
 }
 
 func TestCollectionFind_DefaultLimitExceedsMax_Clamped(t *testing.T) {
@@ -630,6 +652,7 @@ func TestCollectionFind_BadRequestBody(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `not json`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error reading body request")
 }
 
 func TestCollectionFind_Success(t *testing.T) {
@@ -690,6 +713,7 @@ func TestCollectionFind_MongoError(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `{}`)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error running find")
 }
 
 // ---- collectionCount ----
@@ -700,6 +724,7 @@ func TestCollectionCount_MissingDatabaseParam(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/count", `{}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Database name was not passed, one is needed", errorBody(t, w))
 }
 
 func TestCollectionCount_MissingCollectionName(t *testing.T) {
@@ -714,7 +739,7 @@ func TestCollectionCount_MissingCollectionName(t *testing.T) {
 	s.collectionCount(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Collection name was not passed")
+	assert.Equal(t, "Collection name was not passed", errorBody(t, w))
 }
 
 func TestCollectionCount_BadRequestBody(t *testing.T) {
@@ -723,6 +748,7 @@ func TestCollectionCount_BadRequestBody(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/count", `not json`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error reading body request")
 }
 
 func TestCollectionCount_Success(t *testing.T) {
@@ -758,6 +784,7 @@ func TestCollectionCount_MongoError(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/count", `{}`)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error running find")
 }
 
 // ---- collectionAggregate ----
@@ -768,6 +795,7 @@ func TestCollectionAggregate_MissingDatabaseParam(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"Aggregate":[]}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Database name was not passed, one is needed", errorBody(t, w))
 }
 
 func TestCollectionAggregate_MissingCollectionName(t *testing.T) {
@@ -782,7 +810,7 @@ func TestCollectionAggregate_MissingCollectionName(t *testing.T) {
 	s.collectionAggregate(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Collection name was not passed")
+	assert.Equal(t, "Collection name was not passed", errorBody(t, w))
 }
 
 func TestCollectionAggregate_BadRequestBody(t *testing.T) {
@@ -791,6 +819,7 @@ func TestCollectionAggregate_BadRequestBody(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `not json`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error reading body request")
 }
 
 func TestCollectionAggregate_NonArrayAggregateField(t *testing.T) {
@@ -800,7 +829,7 @@ func TestCollectionAggregate_NonArrayAggregateField(t *testing.T) {
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"Aggregate":"not-an-array"}`)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Aggregate field must be an array")
+	assert.Equal(t, "Aggregate field must be an array", errorBody(t, w))
 }
 
 func TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline(t *testing.T) {
@@ -861,6 +890,7 @@ func TestCollectionAggregate_BadLimit(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate?limit=notanumber", `{"Aggregate":[]}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Limit is not an int")
 }
 
 func TestCollectionAggregate_LimitExceedsMax(t *testing.T) {
@@ -869,6 +899,7 @@ func TestCollectionAggregate_LimitExceedsMax(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate?limit=50", `{"Aggregate":[]}`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Passed limit is greater than max limit set by server", errorBody(t, w))
 }
 
 func TestCollectionAggregate_DefaultLimitExceedsMax_Clamped(t *testing.T) {
@@ -986,7 +1017,7 @@ func TestCollectionAggregate_NonArrayLowercaseAggregateField(t *testing.T) {
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"aggregate":"not-an-array"}`)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Aggregate field must be an array")
+	assert.Equal(t, "Aggregate field must be an array", errorBody(t, w))
 }
 
 func TestCollectionAggregate_Success(t *testing.T) {
@@ -1024,4 +1055,5 @@ func TestCollectionAggregate_MongoError(t *testing.T) {
 
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", `{"Aggregate":[]}`)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error running aggregate")
 }


### PR DESCRIPTION
## Summary
- Every `/api/...` failure response now returns a `{"error": "<message>"}` JSON body instead of plain text, via a new shared `writeError` helper used by all four handlers and `resolveDB`. Status codes are unchanged.
- This is a consumer-visible breaking change for anyone matching on the old plain-text error body — documented in `CHANGELOG.md` (new file) under `Unreleased`/targeted `v1.1.0`, and in a new "Error responses" section in `README.md`. The `AddCustomGET` example in the README/package doc was also updated to demonstrate the same pattern.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (container-backed Mongo tests included; ran successfully with Docker available)
- [x] Updated existing error-path tests to assert the JSON envelope shape (via a new `errorBody` test helper that decodes `{"error": "..."}` and checks the `Content-Type` header), not just the status code, per the issue's definition of done.

Fixes #31