### PR TITLE
Request binding: empty body means empty filter; use ShouldBindJSON consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+
+- `find` and `count` no longer reject a request with an empty body; an empty body is
+  now treated as an empty filter instead of a `400`. `aggregate` now binds the request
+  body as JSON regardless of the `Content-Type` header, instead of only when
+  `Content-Type: application/json` is set. (#32)
+
 ### Changed
 
 - **Breaking:** All `/api/...` route failure responses now return a JSON envelope,

--- a/server.go
+++ b/server.go
@@ -58,6 +58,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os/signal"
@@ -304,6 +305,18 @@ func writeError(ctx *gin.Context, status int, message string) {
 	ctx.JSON(status, bson.M{"error": message})
 }
 
+// bindJSONBody decodes the request body as JSON into v, always via the JSON
+// binder regardless of the request's Content-Type. An empty body (io.EOF) is
+// treated as success, leaving v at its zero value, so callers can omit the
+// body entirely rather than being forced to send "{}".
+func bindJSONBody(ctx *gin.Context, v any) error {
+	err := ctx.ShouldBindJSON(v)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
 // resolveDB determines the target database for a /api/collections/... route:
 // Options.DefaultDB if set, otherwise the "database" query param. If neither
 // is available it writes the 400 response itself and returns ok=false, so
@@ -386,12 +399,14 @@ func (s *server) collectionFind(ctx *gin.Context) {
 		limit = s.maxLimit
 	}
 
-	// Get filter from request body
+	// Get filter from request body. An empty body means "no filter".
 	var filter bson.M
-	err = ctx.ShouldBindJSON(&filter)
-	if err != nil {
+	if err := bindJSONBody(ctx, &filter); err != nil {
 		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
+	}
+	if filter == nil {
+		filter = bson.M{}
 	}
 
 	opts := options.Find()
@@ -435,12 +450,14 @@ func (s *server) collectionCount(ctx *gin.Context) {
 		return
 	}
 
-	// Get filter from request body
+	// Get filter from request body. An empty body means "no filter".
 	var filter bson.M
-	err := ctx.ShouldBindJSON(&filter)
-	if err != nil {
+	if err := bindJSONBody(ctx, &filter); err != nil {
 		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
+	}
+	if filter == nil {
+		filter = bson.M{}
 	}
 
 	// Run find
@@ -497,10 +514,12 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 		limit = s.maxLimit
 	}
 
-	// Get request body
+	// Get request body. An empty body means "no pipeline". Bound via the JSON
+	// binder specifically (not ShouldBind, which picks a binder from
+	// Content-Type and would fall through to form binding, misinterpreting a
+	// valid JSON body without a Content-Type: application/json header).
 	var reqBody map[string]any
-	err = ctx.ShouldBind(&reqBody)
-	if err != nil {
+	if err := bindJSONBody(ctx, &reqBody); err != nil {
 		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -156,8 +156,7 @@ func newTestServer(client *mongo.Client, defaultDB string, findLimit, findMaxLim
 	}
 }
 
-// doJSONRequest issues a request with a JSON content type, which the
-// aggregate route's ctx.ShouldBind depends on to select JSON binding.
+// doJSONRequest issues a request with a JSON content type.
 func doJSONRequest(router http.Handler, method, path, body string) *httptest.ResponseRecorder {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(method, path, bytes.NewBufferString(body))
@@ -655,6 +654,30 @@ func TestCollectionFind_BadRequestBody(t *testing.T) {
 	assert.Contains(t, errorBody(t, w), "Error reading body request")
 }
 
+func TestCollectionFind_EmptyBodyUsesEmptyFilter(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a"},
+		bson.M{"name": "b"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 2)
+}
+
 func TestCollectionFind_Success(t *testing.T) {
 	client := requireMongo(t)
 	dbName := testDBName(t)
@@ -749,6 +772,31 @@ func TestCollectionCount_BadRequestBody(t *testing.T) {
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/count", `not json`)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	assert.Contains(t, errorBody(t, w), "Error reading body request")
+}
+
+func TestCollectionCount_EmptyBodyUsesEmptyFilter(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a"},
+		bson.M{"name": "b"},
+		bson.M{"name": "c"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/count", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct{ Count int64 }
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.EqualValues(t, 3, body.Count)
 }
 
 func TestCollectionCount_Success(t *testing.T) {
@@ -855,6 +903,60 @@ func TestCollectionAggregate_MissingAggregateFieldUsesEmptyPipeline(t *testing.T
 	var results []map[string]any
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
 	assert.Len(t, results, 1)
+}
+
+func TestCollectionAggregate_EmptyBodyUsesEmptyPipeline(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertOne(ctx, bson.M{"name": "a"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/aggregate", "")
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	assert.Len(t, results, 1)
+}
+
+func TestCollectionAggregate_AcceptsJSONWithoutContentTypeHeader(t *testing.T) {
+	// Regression test: collectionAggregate previously used ctx.ShouldBind,
+	// which selects a binder from Content-Type and fell through to form
+	// binding when the header was absent, failing on a well-formed JSON body.
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a", "qty": 1},
+		bson.M{"name": "b", "qty": 2},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/collections/widgets/aggregate",
+		bytes.NewBufferString(`{"Aggregate":[{"$match":{"name":"a"}}]}`))
+	// Deliberately no Content-Type header set.
+	s.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, "a", results[0]["name"])
 }
 
 func TestCollectionAggregate_LowercaseAggregateKeyIsApplied(t *testing.T) {


### PR DESCRIPTION
## Summary
- `find` and `count` no longer 400 on an empty request body (previously `"Error reading body request: EOF"`); an empty body is now treated as an empty filter (`{}`), matching "find everything" / "count everything" semantics.
- `collectionAggregate` now uses `ShouldBindJSON` instead of `ShouldBind`, so a valid JSON body is bound correctly even without a `Content-Type: application/json` header (previously fell through to form binding and failed with a confusing `"can not convert to map of strings"` error).
- Adds a shared `bindJSONBody` helper (`server.go`) used by all three handlers: binds via the JSON binder and treats `io.EOF` as success rather than an error, leaving the target at its zero value.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, Mongo-backed tests via testcontainers) — all pass
- [x] `gofmt -l .` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] New tests added:
  - `TestCollectionFind_EmptyBodyUsesEmptyFilter`
  - `TestCollectionCount_EmptyBodyUsesEmptyFilter`
  - `TestCollectionAggregate_EmptyBodyUsesEmptyPipeline`
  - `TestCollectionAggregate_AcceptsJSONWithoutContentTypeHeader`
- [x] Existing bad-body tests (`TestCollectionFind_BadRequestBody`, `TestCollectionCount_BadRequestBody`, `TestCollectionAggregate_BadRequestBody`) still pass, confirming malformed (non-empty) JSON still 400s.

Fixes #32