### PR TITLE
find: add sort, skip, and projection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+
+- `find` now supports `sort` and `skip` url params, and a `projection` field in the
+  request body, mapping to `options.Find().SetSort`/`SetSkip`/`SetProjection`
+  respectively. `sort` is a JSON object url-encoded into the query string (e.g.
+  `?sort={"createdAt":-1}`); `projection` is a reserved top-level key in the request
+  body, matched case-insensitively, with the remaining body keys forming the filter as
+  before. (#33)
+
 ### Fixed
 
 - `find` and `count` no longer reject a request with an empty body; an empty body is

--- a/README.md
+++ b/README.md
@@ -140,6 +140,20 @@ server-wide default (`FindLimit`) and max (`FindMaxLimit`) if configured (see
 [`Options`](#options) below). For `aggregate`, the limit is applied as a `$limit` stage
 appended to the end of the caller's pipeline.
 
+`find` additionally accepts:
+
+- `skip` url param — a non-negative int, mapped to `options.Find().SetSkip`.
+- `sort` url param — a JSON object url-encoded into the query string, e.g.
+  `?sort={"createdAt":-1}`, mapped to `options.Find().SetSort`. A JSON sort spec doesn't fit
+  a plain scalar query param, so it travels as an encoded JSON string like this rather than
+  as nested query keys.
+- `projection` — not a url param, but a top-level key in the request body (matched
+  case-insensitively), mapped to `options.Find().SetProjection`. Everything else in the body
+  is the filter, e.g. `{"UserName": "Jon", "projection": {"UserName": 1}}` filters on
+  `UserName` and returns only that field. This makes `projection` a reserved top-level
+  filter key — a genuine field named `projection` can't be filtered on directly through this
+  route.
+
 ### Error responses
 
 Every `/api/...` route returns a JSON envelope on failure, `{"error": "<message>"}`,

--- a/server.go
+++ b/server.go
@@ -56,6 +56,7 @@ package gomongoapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -317,6 +318,41 @@ func bindJSONBody(ctx *gin.Context, v any) error {
 	return nil
 }
 
+// parseSortParam parses the "sort" url query param (a JSON object, e.g.
+// {"createdAt":-1,"name":1}) into an ordered sort specification for
+// options.Find().SetSort. It's decoded manually via encoding/json's token
+// stream rather than into a map, because Go map iteration order is
+// randomized and, for a multi-field sort, field order is significant.
+func parseSortParam(raw string) (bson.D, error) {
+	dec := json.NewDecoder(strings.NewReader(raw))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, errors.New(`sort must be a JSON object, e.g. {"field":1}`)
+	}
+
+	var sort bson.D
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, errors.New("sort keys must be strings")
+		}
+
+		var direction int
+		if err := dec.Decode(&direction); err != nil || (direction != 1 && direction != -1) {
+			return nil, fmt.Errorf("sort value for %q must be 1 or -1", key)
+		}
+		sort = append(sort, bson.E{Key: key, Value: direction})
+	}
+	return sort, nil
+}
+
 // resolveDB determines the target database for a /api/collections/... route:
 // Options.DefaultDB if set, otherwise the "database" query param. If neither
 // is available it writes the 400 response itself and returns ok=false, so
@@ -357,10 +393,15 @@ func (s *server) getCollections(c *gin.Context) {
 }
 
 // Runs a find on the collection. /collections/:name/find
-// Valid URL parameter are 'database' and 'limit'
-// Request body should have the find filter
+// Valid URL parameters are 'database', 'limit', 'skip', and 'sort'.
+// 'sort' is a JSON object url-encoded into the query string, e.g.
+// ?sort={"createdAt":-1}, since a JSON sort spec can't be a plain scalar.
+// Request body is the find filter, with an optional top-level "projection"
+// key (matched case-insensitively) pulled out as the projection spec;
+// remaining keys form the filter. This makes "projection" a reserved
+// top-level filter key.
 //
-//	ex) Request Body: {"UserName": "Jon"}
+//	ex) Request Body: {"UserName": "Jon", "projection": {"UserName": 1}}
 func (s *server) collectionFind(ctx *gin.Context) {
 
 	dbName, ok := s.resolveDB(ctx)
@@ -399,12 +440,55 @@ func (s *server) collectionFind(ctx *gin.Context) {
 		limit = s.maxLimit
 	}
 
-	// Get filter from request body. An empty body means "no filter".
-	var filter bson.M
-	if err := bindJSONBody(ctx, &filter); err != nil {
+	// Get skip, defaulting to 0 (no skip) if not passed.
+	var skip int
+	if skipParam, skipPassed := ctx.GetQuery("skip"); skipPassed {
+		skip, err = strconv.Atoi(skipParam)
+		if err != nil {
+			writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Skip is not an int: %s", err.Error()))
+			return
+		}
+		if skip < 0 {
+			writeError(ctx, http.StatusBadRequest, "Skip must be a non-negative int")
+			return
+		}
+	}
+
+	// Get sort, defaulting to no sort if not passed.
+	var sort bson.D
+	if sortParam, sortPassed := ctx.GetQuery("sort"); sortPassed {
+		sort, err = parseSortParam(sortParam)
+		if err != nil {
+			writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Invalid sort parameter: %s", err.Error()))
+			return
+		}
+	}
+
+	// Get filter from request body. An empty body means "no filter". A
+	// top-level "projection" key (matched case-insensitively) is pulled out
+	// as the projection spec; the remaining keys form the filter.
+	var rawBody map[string]any
+	if err := bindJSONBody(ctx, &rawBody); err != nil {
 		writeError(ctx, http.StatusBadRequest, fmt.Sprintf("Error reading body request: %s", err.Error()))
 		return
 	}
+
+	var projection bson.M
+	for key, val := range rawBody {
+		if !strings.EqualFold(key, "projection") {
+			continue
+		}
+		m, ok := val.(map[string]any)
+		if !ok {
+			writeError(ctx, http.StatusBadRequest, "Projection field must be an object")
+			return
+		}
+		projection = bson.M(m)
+		delete(rawBody, key)
+		break
+	}
+
+	filter := bson.M(rawBody)
 	if filter == nil {
 		filter = bson.M{}
 	}
@@ -412,6 +496,13 @@ func (s *server) collectionFind(ctx *gin.Context) {
 	opts := options.Find()
 	opts.SetLimit(int64(limit))
 	opts.SetAllowDiskUse(true)
+	opts.SetSkip(int64(skip))
+	if len(sort) > 0 {
+		opts.SetSort(sort)
+	}
+	if projection != nil {
+		opts.SetProjection(projection)
+	}
 
 	// Run find
 	cursor, err := s.mongoClient.Database(dbName).Collection(collName).Find(ctx.Request.Context(), filter, opts)

--- a/server_test.go
+++ b/server_test.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -737,6 +738,217 @@ func TestCollectionFind_MongoError(t *testing.T) {
 	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `{}`)
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 	assert.Contains(t, errorBody(t, w), "Error running find")
+}
+
+func TestParseSortParam(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		want    bson.D
+		wantErr bool
+	}{
+		{name: "single field ascending", raw: `{"createdAt":1}`, want: bson.D{{Key: "createdAt", Value: 1}}},
+		{name: "single field descending", raw: `{"createdAt":-1}`, want: bson.D{{Key: "createdAt", Value: -1}}},
+		{name: "multi field preserves order", raw: `{"a":1,"b":-1}`, want: bson.D{{Key: "a", Value: 1}, {Key: "b", Value: -1}}},
+		{name: "empty object", raw: `{}`, want: nil},
+		{name: "not json", raw: `notjson`, wantErr: true},
+		{name: "not an object", raw: `[1,2]`, wantErr: true},
+		{name: "invalid direction", raw: `{"a":2}`, wantErr: true},
+		{name: "non numeric direction", raw: `{"a":"asc"}`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSortParam(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCollectionFind_BadSkip(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find?skip=notanumber", `{}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Skip is not an int")
+}
+
+func TestCollectionFind_NegativeSkip(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find?skip=-1", `{}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Skip must be a non-negative int", errorBody(t, w))
+}
+
+func TestCollectionFind_BadSort(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find?sort=notjson", `{}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, errorBody(t, w), "Invalid sort parameter")
+}
+
+func TestCollectionFind_ProjectionFieldNotObject(t *testing.T) {
+	s := newTestServer(nil, "app", 100, 0)
+	s.createRoutes()
+
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", `{"projection":"notanobject"}`)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "Projection field must be an object", errorBody(t, w))
+}
+
+func TestCollectionFind_RespectsSort(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"n": 3},
+		bson.M{"n": 1},
+		bson.M{"n": 2},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	path := "/api/collections/widgets/find?sort=" + url.QueryEscape(`{"n":1}`)
+	w := doJSONRequest(s.router, http.MethodPost, path, `{}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 3)
+	assert.EqualValues(t, 1, results[0]["n"])
+	assert.EqualValues(t, 2, results[1]["n"])
+	assert.EqualValues(t, 3, results[2]["n"])
+}
+
+func TestCollectionFind_MultiFieldSortOrderPreserved(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"group": "b", "n": 1},
+		bson.M{"group": "a", "n": 2},
+		bson.M{"group": "a", "n": 1},
+		bson.M{"group": "b", "n": 2},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	// Sort by group ascending, then n descending within each group. This is
+	// only correct if the sort key order from the JSON object is preserved.
+	path := "/api/collections/widgets/find?sort=" + url.QueryEscape(`{"group":1,"n":-1}`)
+	w := doJSONRequest(s.router, http.MethodPost, path, `{}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 4)
+	assert.Equal(t, "a", results[0]["group"])
+	assert.EqualValues(t, 2, results[0]["n"])
+	assert.Equal(t, "a", results[1]["group"])
+	assert.EqualValues(t, 1, results[1]["n"])
+	assert.Equal(t, "b", results[2]["group"])
+	assert.EqualValues(t, 2, results[2]["n"])
+	assert.Equal(t, "b", results[3]["group"])
+	assert.EqualValues(t, 1, results[3]["n"])
+}
+
+func TestCollectionFind_RespectsSkip(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	docs := make([]any, 0, 5)
+	for i := range 5 {
+		docs = append(docs, bson.M{"n": i})
+	}
+	_, err := coll.InsertMany(ctx, docs)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	path := "/api/collections/widgets/find?skip=2&sort=" + url.QueryEscape(`{"n":1}`)
+	w := doJSONRequest(s.router, http.MethodPost, path, `{}`)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 3)
+	assert.EqualValues(t, 2, results[0]["n"])
+	assert.EqualValues(t, 3, results[1]["n"])
+	assert.EqualValues(t, 4, results[2]["n"])
+}
+
+func TestCollectionFind_RespectsProjection(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a", "qty": 5, "secret": "x"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	body := `{"name":"a","projection":{"name":1,"qty":1,"_id":0}}`
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, map[string]any{"name": "a", "qty": float64(5)}, results[0])
+}
+
+func TestCollectionFind_UppercaseProjectionKeyIsApplied(t *testing.T) {
+	client := requireMongo(t)
+	dbName := testDBName(t)
+	ctx := context.Background()
+
+	coll := client.Database(dbName).Collection("widgets")
+	_, err := coll.InsertMany(ctx, []any{
+		bson.M{"name": "a", "qty": 5, "secret": "x"},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Database(dbName).Drop(context.Background()) })
+
+	s := newTestServer(client, dbName, 100, 0)
+	s.createRoutes()
+
+	body := `{"name":"a","Projection":{"name":1,"_id":0}}`
+	w := doJSONRequest(s.router, http.MethodPost, "/api/collections/widgets/find", body)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 1)
+	assert.Equal(t, map[string]any{"name": "a"}, results[0])
 }
 
 // ---- collectionCount ----


### PR DESCRIPTION
## Summary

- Adds `sort` and `skip` url params to `find`, mapped to `options.Find().SetSort`/`SetSkip`. `sort` is a JSON object url-encoded into the query string (e.g. `?sort={"createdAt":-1}`) since a JSON sort spec doesn't fit a plain scalar query param, and is decoded with an order-preserving parser (`parseSortParam`) so multi-field sorts respect the caller's field order — a plain `map[string]int` would lose that via Go's randomized map iteration.
- Adds `projection` support as a reserved top-level key in the `find` request body (matched case-insensitively), mapped to `options.Find().SetProjection`. The remaining body keys form the filter as before, so this is a small, documented departure from "the whole body is the filter": a genuine field literally named `projection` can no longer be filtered on directly through this route.
- Updates README (routes section) and CHANGELOG (`Unreleased`/`Added`) per the issue's definition of done.

## Design notes

The issue left the query-string-vs-body question open. Landed on: `skip` as a url param (plain int, same shape as `limit`), `sort` as a url param carrying url-encoded JSON (the issue's own text flags the url-encoding awkwardness but a body-wrapper change would be a bigger departure), and `projection` in the body (explicitly proposed that way in the issue and in `SUGGESTIONS.md` §3) using the same case-insensitive reserved-key pattern `collectionAggregate` already uses for its `Aggregate` key.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, container-backed tests included — Docker available locally)
- [x] `golangci-lint run ./...` — 0 issues
- [x] New table-style unit tests for bad input: bad/negative `skip`, bad `sort`, non-object `projection`
- [x] New unit tests for `parseSortParam` covering valid/invalid shapes and multi-field order preservation
- [x] New container-backed tests: `sort` applied, multi-field `sort` order preserved, `skip` applied (combined with `sort` for a deterministic assertion), `projection` applied, case-insensitive `Projection` key applied

Fixes #33