### PR TITLE
Add /api/health readiness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ trusted internal caller, add a rate-limiting gin middleware (e.g.
 
 | Path                                | HTTP Verb | Body  | Result                                                                                                |
 | ------------------------------------ | --------- | ----- | ------------------------------------------------------------------------------------------------------ |
-| `/`                                   | GET       | Empty | Always 200, used to test the connection.                                                               |
+| `/`                                   | GET       | Empty | Always 200, used to test the connection (liveness).                                                    |
+| `/api/health`                         | GET       | Empty | Pings MongoDB; 200 if reachable, 503 otherwise (readiness).                                             |
 | `/api/databases`                      | GET       | Empty | Returns list of available databases, unless a default database is set.                                 |
 | `/api/collections`                    | GET       | Empty | Returns a list of collections for the default db or the one passed in the `database` url param.       |
 | `/api/collections/:name/find`         | POST      | JSON  | Returns the result of a find on collection `:name`. DB is either the default or `database` url param.  |
@@ -177,6 +178,7 @@ be customized with the setter methods below before being passed to `gomongoapi.N
 | `DefaultDB` / `SetDefaultDB(string)`            | none (unset)         | If set, all routes operate against this database and the `database` url param is not needed.    |
 | `FindLimit` / `SetFindLimit(int)`               | `1000`               | Default number of records returned by `find` and `aggregate` when no `limit` url param is passed. |
 | `FindMaxLimit` / `SetFindMaxLimit(int)`         | `0` (no limit)       | Upper bound on the `limit` url param for `find` and `aggregate`. Requests above this are rejected. |
+| `HealthCheckTimeout` / `SetHealthCheckTimeout(time.Duration)` | `5s`  | Upper bound on the Mongo ping issued by `/api/health`.                                          |
 
 ## Custom routes and middleware
 

--- a/option.go
+++ b/option.go
@@ -45,20 +45,25 @@ type Options struct {
 	// Upper bound on how long the HTTP server waits to read a request's headers, guarding against
 	// slow-header (Slowloris) attacks. Default is 5 seconds.
 	ReadHeaderTimeout time.Duration
+
+	// Upper bound on the Mongo ping issued by the /api/health readiness route, so a hung Mongo
+	// host can't make the health check itself hang. Default is 5 seconds.
+	HealthCheckTimeout time.Duration
 }
 
 // ServerOptions returns server options with default values.
 func ServerOptions() *Options {
 	return &Options{
-		Router:            gin.Default(),
-		Address:           ":8080",
-		CustomRouteName:   "custom",
-		MongoClientOpts:   options.Client(),
-		FindLimit:         1000,
-		FindMaxLimit:      0,
-		ConnectTimeout:    defaultConnectTimeout,
-		ShutdownTimeout:   defaultShutdownTimeout,
-		ReadHeaderTimeout: defaultReadHeaderTimeout,
+		Router:             gin.Default(),
+		Address:            ":8080",
+		CustomRouteName:    "custom",
+		MongoClientOpts:    options.Client(),
+		FindLimit:          1000,
+		FindMaxLimit:       0,
+		ConnectTimeout:     defaultConnectTimeout,
+		ShutdownTimeout:    defaultShutdownTimeout,
+		ReadHeaderTimeout:  defaultReadHeaderTimeout,
+		HealthCheckTimeout: defaultHealthCheckTimeout,
 	}
 }
 
@@ -119,4 +124,10 @@ func (o *Options) SetShutdownTimeout(shutdownTimeout time.Duration) {
 // request's headers.
 func (o *Options) SetReadHeaderTimeout(readHeaderTimeout time.Duration) {
 	o.ReadHeaderTimeout = readHeaderTimeout
+}
+
+// SetHealthCheckTimeout sets the upper bound on the Mongo ping issued by the /api/health
+// readiness route.
+func (o *Options) SetHealthCheckTimeout(healthCheckTimeout time.Duration) {
+	o.HealthCheckTimeout = healthCheckTimeout
 }

--- a/option_test.go
+++ b/option_test.go
@@ -24,6 +24,7 @@ func TestServerOptionsDefaults(t *testing.T) {
 	assert.Equal(t, 10*time.Second, opts.ConnectTimeout)
 	assert.Equal(t, 10*time.Second, opts.ShutdownTimeout)
 	assert.Equal(t, 5*time.Second, opts.ReadHeaderTimeout)
+	assert.Equal(t, 5*time.Second, opts.HealthCheckTimeout)
 }
 
 func TestSetRouter(t *testing.T) {
@@ -128,4 +129,12 @@ func TestSetReadHeaderTimeout(t *testing.T) {
 	opts.SetReadHeaderTimeout(15 * time.Second)
 
 	assert.Equal(t, 15*time.Second, opts.ReadHeaderTimeout)
+}
+
+func TestSetHealthCheckTimeout(t *testing.T) {
+	opts := ServerOptions()
+
+	opts.SetHealthCheckTimeout(2 * time.Second)
+
+	assert.Equal(t, 2*time.Second, opts.HealthCheckTimeout)
 }

--- a/server.go
+++ b/server.go
@@ -10,7 +10,8 @@ Available default routes:
 	+----------------------------------+-----------+-------+------------------------------------------------------------------------------------------------------+
 	| Path                             | HTTP Verb | Body  | Result                                                                                               |
 	+----------------------------------+-----------+-------+------------------------------------------------------------------------------------------------------+
-	| /                                |    GET    | Empty | Always 200, test connection.                                                                         |
+	| /                                |    GET    | Empty | Always 200, test connection (liveness).                                                              |
+	| /api/health                      |    GET    | Empty | Pings MongoDB, 200 if reachable, 503 otherwise (readiness).                                          |
 	| /api/databases                   |    GET    | Empty | Returns list of available databases, unless a default is set.                                        |
 	| /api/collections                 |    GET    | Empty | Returns a list collections to the default db or the one passed in url param.                         |
 	| /api/collections/:name/find      |    POST   | JSON  | Returns result of find on the collection name. DB is either default or one passed in url param.      |
@@ -88,6 +89,11 @@ const defaultShutdownTimeout = 10 * time.Second
 // request's headers, guarding against slow-header (Slowloris) attacks.
 const defaultReadHeaderTimeout = 5 * time.Second
 
+// defaultHealthCheckTimeout bounds how long the /api/health route waits on
+// its Mongo ping, so a hung Mongo host can't make the health check itself
+// hang.
+const defaultHealthCheckTimeout = 5 * time.Second
+
 // Server interface for mongo api server
 type Server interface {
 
@@ -133,9 +139,10 @@ type server struct {
 
 	// Timeouts for startup and shutdown. Populated from Options by
 	// NewServer; tests construct a *server directly to override them.
-	connectTimeout    time.Duration
-	shutdownTimeout   time.Duration
-	readHeaderTimeout time.Duration
+	connectTimeout     time.Duration
+	shutdownTimeout    time.Duration
+	readHeaderTimeout  time.Duration
+	healthCheckTimeout time.Duration
 }
 
 // NewServer creates a new server. Must pass in Mongo Client Options.
@@ -155,17 +162,18 @@ func NewServer(opts *Options) Server {
 	findLimit := strconv.Itoa(opts.FindLimit)
 
 	return &server{
-		mongoClientOpts:   opts.MongoClientOpts,
-		router:            router,
-		apiRouter:         apiRouter,
-		customRouter:      customRouter,
-		address:           opts.Address,
-		defaultDB:         opts.DefaultDB,
-		findLimit:         findLimit,
-		maxLimit:          opts.FindMaxLimit,
-		connectTimeout:    opts.ConnectTimeout,
-		shutdownTimeout:   opts.ShutdownTimeout,
-		readHeaderTimeout: opts.ReadHeaderTimeout,
+		mongoClientOpts:    opts.MongoClientOpts,
+		router:             router,
+		apiRouter:          apiRouter,
+		customRouter:       customRouter,
+		address:            opts.Address,
+		defaultDB:          opts.DefaultDB,
+		findLimit:          findLimit,
+		maxLimit:           opts.FindMaxLimit,
+		connectTimeout:     opts.ConnectTimeout,
+		shutdownTimeout:    opts.ShutdownTimeout,
+		readHeaderTimeout:  opts.ReadHeaderTimeout,
+		healthCheckTimeout: opts.HealthCheckTimeout,
 	}
 }
 
@@ -254,6 +262,7 @@ func (s *server) createRoutes() {
 	})
 
 	// Create api group
+	s.apiRouter.GET("/health", s.health)
 	s.apiRouter.GET("/databases", s.getDatabases)
 	s.apiRouter.GET("/collections", s.getCollections)
 	s.apiRouter.POST("/collections/:name/find", s.collectionFind)
@@ -271,6 +280,25 @@ func (s *server) SetAPIMiddleware(middleware ...gin.HandlerFunc) {
 // This allows custom additions like logging, auth, etc
 func (s *server) SetCustomMiddleware(middleware ...gin.HandlerFunc) {
 	s.customRouter.Use(middleware...)
+}
+
+// Route to check readiness: pings MongoDB and returns 503 if it's
+// unreachable, unlike "/" which always returns 200 regardless of the Mongo
+// connection's state. The ping is bounded by healthCheckTimeout so a hung
+// Mongo host can't make this route itself hang.
+func (s *server) health(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), s.healthCheckTimeout)
+	defer cancel()
+
+	if err := s.mongoClient.Ping(ctx, nil); err != nil {
+		c.JSON(http.StatusServiceUnavailable, bson.M{
+			"status": "error",
+			"error":  fmt.Sprintf("Error pinging MongoDB: %s", err.Error()),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, bson.M{"status": "ok"})
 }
 
 // Route to get all database names

--- a/server_test.go
+++ b/server_test.go
@@ -147,13 +147,14 @@ func TestTestDBName_StaysWithinMongoLimit(t *testing.T) {
 func newTestServer(client *mongo.Client, defaultDB string, findLimit, findMaxLimit int) *server {
 	router := gin.New()
 	return &server{
-		router:       router,
-		apiRouter:    router.Group("/api"),
-		customRouter: router.Group("custom"),
-		mongoClient:  client,
-		defaultDB:    defaultDB,
-		findLimit:    strconv.Itoa(findLimit),
-		maxLimit:     findMaxLimit,
+		router:             router,
+		apiRouter:          router.Group("/api"),
+		customRouter:       router.Group("custom"),
+		mongoClient:        client,
+		defaultDB:          defaultDB,
+		findLimit:          strconv.Itoa(findLimit),
+		maxLimit:           findMaxLimit,
+		healthCheckTimeout: defaultHealthCheckTimeout,
 	}
 }
 
@@ -193,6 +194,7 @@ func TestNewServer(t *testing.T) {
 	opts.SetConnectTimeout(20 * time.Second)
 	opts.SetShutdownTimeout(15 * time.Second)
 	opts.SetReadHeaderTimeout(3 * time.Second)
+	opts.SetHealthCheckTimeout(2 * time.Second)
 	require.NoError(t, opts.SetCustomRouteName("myroutes"))
 
 	srv := NewServer(opts)
@@ -210,6 +212,7 @@ func TestNewServer(t *testing.T) {
 	assert.Equal(t, 20*time.Second, s.connectTimeout)
 	assert.Equal(t, 15*time.Second, s.shutdownTimeout)
 	assert.Equal(t, 3*time.Second, s.readHeaderTimeout)
+	assert.Equal(t, 2*time.Second, s.healthCheckTimeout)
 	require.NotNil(t, s.apiRouter)
 	require.NotNil(t, s.customRouter)
 	assert.Equal(t, "/api", s.apiRouter.BasePath())
@@ -244,6 +247,39 @@ func TestServer_RootRoute(t *testing.T) {
 	s.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// ---- /api/health ----
+
+func TestHealth_Success(t *testing.T) {
+	client := requireMongo(t)
+
+	s := newTestServer(client, "", 100, 0)
+	s.createRoutes()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	s.router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var body struct{ Status string }
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, "ok", body.Status)
+}
+
+func TestHealth_MongoUnreachable(t *testing.T) {
+	client := disconnectedClient(t)
+
+	s := newTestServer(client, "", 100, 0)
+	s.createRoutes()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Contains(t, errorBody(t, w), "Error pinging MongoDB")
 }
 
 // ---- Middleware / custom routes ----


### PR DESCRIPTION
## Summary
- Adds `/api/health` (`GET`), which pings MongoDB with a bounded timeout and returns `200 {"status":"ok"}` when reachable, `503 {"status":"error","error":"..."}` otherwise.
- Adds `HealthCheckTimeout` / `SetHealthCheckTimeout(time.Duration)` to `Options` (default `5s`) bounding the ping so a hung Mongo host can't make the health check itself hang.
- `/` is unchanged — still an unconditional 200 liveness check.
- Documents the new route and option in both the README routes/options tables and the package doc comment's routes table.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, container-backed)
- [x] `golangci-lint run ./...`
- [x] New tests: `TestHealth_Success` (container-backed, real ping succeeds), `TestHealth_MongoUnreachable` (disconnected client, expects 503 + error body), `TestServerOptionsDefaults`/`TestSetHealthCheckTimeout` (option defaults/setter), `TestNewServer` extended to assert `healthCheckTimeout` wiring

Fixes #34