### PR TITLE
Add CONTRIBUTING.md, CI badge, and scripts/release.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thanks for considering a contribution to `gomongoapi`. This is a small library — the whole
+public API is `option.go` and `server.go` — so most changes are small in scope too.
+
+## Getting started
+
+```sh
+make build   # go build ./...
+make vet     # go vet ./...
+make lint    # golangci-lint run ./... (requires golangci-lint installed locally)
+make test    # go vet, then go test ./...
+```
+
+`make test` runs the full suite, including container-backed tests that spin up a real
+MongoDB via [testcontainers-go](https://github.com/testcontainers/testcontainers-go). Those
+tests skip gracefully (`t.Skipf`) if Docker isn't available, so `make test` still passes
+without it — but if you can, run with Docker so you actually exercise the Mongo-backed
+paths you're changing.
+
+To run a single test:
+
+```sh
+go test ./... -run TestCollectionFind_Success -v
+```
+
+## Before opening a PR
+
+- Run `make test` and `make vet`; CI runs the same, plus `golangci-lint` and a build of
+  `examples/simpleDemo` (a separate Go module, so it isn't covered by `go build ./...` at
+  the repo root).
+- Keep changes scoped to the issue or bug at hand — avoid bundling unrelated refactors.
+- Add tests for new behavior, following the existing naming and patterns:
+  - `Test<Handler>_<Scenario>` naming, e.g. `TestCollectionFind_Success`,
+    `TestCollectionFind_BadLimit`.
+  - Request-validation-only paths (missing db name, bad limit, malformed body) get
+    table-style unit tests that build a `*server` directly and invoke the handler with
+    `gin.CreateTestContext`/`httptest` — no Mongo needed.
+  - Anything that touches Mongo goes through the shared container in `TestMain`
+    (`server_test.go`), skipping via `sharedMongoErr` when Docker isn't available.
+- Update `CHANGELOG.md` under `## [Unreleased]` for any user-visible change (new option,
+  route, behavior change, bug fix). Follow the existing [Keep a
+  Changelog](https://keepachangelog.com/en/1.1.0/)-style sections (`Added`/`Changed`/
+  `Fixed`/`Security`) and reference the PR/issue number.
+- If you're changing documented behavior, update `README.md` and `CLAUDE.md` alongside the
+  code — both are treated as living documentation, not just onboarding material.
+
+## Design conventions
+
+A few conventions worth knowing before changing handler code (see `CLAUDE.md` for the full
+list):
+
+- Every `/api/collections/...` route resolves its target database via the shared
+  `(*server).resolveDB(ctx) (string, bool)` helper rather than duplicating the
+  default-db/`database`-param logic per handler.
+- `SetAPIMiddleware`/`SetCustomMiddleware`/`SetAPIKey` must be called before `Start()` —
+  gin composes a route's handler chain at registration time, and routes are registered
+  inside `Start()`.
+- Unsafe operators (`$where`/`$function`/`$out`/`$merge`) are rejected by default in
+  `find`/`count`/`aggregate` unless `Options.AllowUnsafeOperators` is set; new query paths
+  that accept a caller-supplied filter or pipeline should run through the same check.
+
+## Reporting issues
+
+Open a GitHub issue with a clear description of the problem or proposal. For bugs, include
+steps to reproduce and, if possible, a minimal example.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gomongoapi
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexland23/gomongoapi.svg)](https://pkg.go.dev/github.com/alexland23/gomongoapi)
+[![CI](https://github.com/alexland23/gomongoapi/actions/workflows/ci.yml/badge.svg)](https://github.com/alexland23/gomongoapi/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/alexland23/gomongoapi/branch/main/graph/badge.svg)](https://codecov.io/gh/alexland23/gomongoapi)
 
 `gomongoapi` is a pure Go package for standing up an HTTP server that exposes a MongoDB

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Cut a release: tag, push, create the GitHub release from the matching
+# CHANGELOG.md section, and close the milestone for that version.
+#
+# Usage: scripts/release.sh <version>
+#   <version> is X.Y.Z, with or without a leading 'v' (e.g. 1.2.0 or v1.2.0).
+#
+# Requires: git, the gh CLI (authenticated), and a "## [X.Y.Z] - ..." section
+# already present in CHANGELOG.md for the version being released.
+
+set -euo pipefail
+
+usage() {
+	echo "Usage: $0 <version>" >&2
+	echo "  <version> is X.Y.Z, with or without a leading 'v', e.g. 1.2.0" >&2
+	exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+	usage
+fi
+
+version="${1#v}"
+tag="v${version}"
+
+if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo "error: version must look like X.Y.Z (got '$1')" >&2
+	exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+	echo "error: gh CLI is required (https://cli.github.com)" >&2
+	exit 1
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+changelog="$repo_root/CHANGELOG.md"
+
+if [[ ! -f "$changelog" ]]; then
+	echo "error: $changelog not found" >&2
+	exit 1
+fi
+
+if git rev-parse "$tag" >/dev/null 2>&1; then
+	echo "error: tag $tag already exists" >&2
+	exit 1
+fi
+
+# Extract the "## [<version>] - ..." section: everything between that
+# heading and the next "## " heading (or end of file), with leading/
+# trailing blank lines trimmed.
+notes="$(awk -v hdr="## [$version]" '
+	index($0, hdr) == 1 { found = 1; next }
+	found && index($0, "## ") == 1 { exit }
+	found { lines[n++] = $0 }
+	END {
+		start = 0
+		end = n - 1
+		while (start < n && lines[start] == "") start++
+		while (end >= start && lines[end] == "") end--
+		for (i = start; i <= end; i++) print lines[i]
+	}
+' "$changelog")"
+
+if [[ -z "$notes" ]]; then
+	echo "error: no CHANGELOG.md section found for [$version] (expected a heading like '## [$version] - YYYY-MM-DD')" >&2
+	exit 1
+fi
+
+echo "Release notes for $tag:"
+echo "---"
+printf '%s\n' "$notes"
+echo "---"
+
+echo "Tagging $tag..."
+git tag -a "$tag" -m "Release $tag"
+
+echo "Pushing $tag..."
+git push origin "$tag"
+
+notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
+printf '%s\n' "$notes" >"$notes_file"
+
+echo "Creating GitHub release $tag..."
+gh release create "$tag" --title "$tag" --notes-file "$notes_file"
+
+# Close the milestone whose title references this version, e.g.
+# "M3: Developer Experience (v1.1.0)". Best-effort: warn rather than fail
+# the whole release if no matching open milestone is found.
+milestone_number="$(gh api "repos/{owner}/{repo}/milestones?state=open" \
+	--jq ".[] | select(.title | contains(\"(v${version})\")) | .number" | head -n1)"
+
+if [[ -n "$milestone_number" ]]; then
+	echo "Closing milestone #$milestone_number..."
+	gh api "repos/{owner}/{repo}/milestones/$milestone_number" -X PATCH -f state=closed >/dev/null
+else
+	echo "warning: no open milestone found with '(v$version)' in its title; skipping milestone close" >&2
+fi
+
+echo "Done: $tag released."


### PR DESCRIPTION
## Summary

Closes out the remaining project-hygiene items from #38 (`CHANGELOG.md` was already added in #31, and #24's CI workflow already exists so the badge dependency is unblocked):

- `CONTRIBUTING.md`: a short contributor-facing doc pointing at `make test`/`make vet`, the container-backed test pattern (skip-if-no-Docker via `sharedMongoErr`), `Test<Handler>_<Scenario>` naming, and the `resolveDB`/middleware-ordering/unsafe-operator conventions already documented in `CLAUDE.md`.
- README: added a CI status badge (`.github/workflows/ci.yml`) alongside the existing pkg.go.dev and codecov badges.
- `scripts/release.sh <version>`: automates the four manual steps used to cut v1.1.0 — extract the matching `## [X.Y.Z]` section from `CHANGELOG.md`, `git tag -a` + push, `gh release create --notes-file` with that section, and close the milestone whose title references `(vX.Y.Z)`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (passes; no Go code touched by this change)
- [x] `bash -n scripts/release.sh` (syntax check)
- [x] Manually verified the CHANGELOG-section-extraction `awk` logic against the real `CHANGELOG.md` (`[1.1.0]` section extracts correctly; a nonexistent version like `[9.9.9]` yields an empty match, which the script treats as an error)
- [ ] `scripts/release.sh` itself not run end-to-end (it tags, pushes, and creates a real GitHub release/closes a milestone — didn't want to actually cut a release as a side effect of this PR)

Fixes #38