### PR TITLE
Add generic AddCustomRoute(method, path, handlers...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ server.SetAPIMiddleware(func(ctx *gin.Context) {
 | `/api/collections/:name/aggregate`    | POST      | JSON  | Returns the result of an aggregate on collection `:name`. DB is either the default or `database` url param. |
 | `/custom/<custom route>`              | GET       | N/A   | User-defined GET route — user controls everything.                                                     |
 | `/custom/<custom route>`              | POST      | N/A   | User-defined POST route — user controls everything.                                                    |
+| `/custom/<custom route>`              | any       | N/A   | User-defined route for any HTTP method via `AddCustomRoute` — user controls everything.                 |
 
 `find` and `aggregate` both accept an optional `limit` url param, and both respect a
 server-wide default (`FindLimit`) and max (`FindMaxLimit`) if configured (see
@@ -264,6 +265,10 @@ server.AddCustomGET("/appUsersCount", func(ctx *gin.Context) {
 
 // Add a custom POST route under /custom
 server.AddCustomPOST("/myRoute", myHandler)
+
+// AddCustomGET/AddCustomPOST are thin wrappers around AddCustomRoute; use it directly
+// for other HTTP methods (PUT, DELETE, PATCH, ...)
+server.AddCustomRoute(http.MethodPut, "/myRoute/:id", myHandler)
 ```
 
 ## License

--- a/server.go
+++ b/server.go
@@ -144,6 +144,11 @@ type Server interface {
 	// Add custom POST request, path will be under the /custom route group
 	AddCustomPOST(relativePath string, handlers ...gin.HandlerFunc)
 
+	// Add a custom route for an arbitrary HTTP method (e.g. PUT, DELETE, PATCH),
+	// path will be under the /custom route group. AddCustomGET/AddCustomPOST are
+	// thin wrappers around this for the common cases.
+	AddCustomRoute(method, relativePath string, handlers ...gin.HandlerFunc)
+
 	// Returns server mongo client.
 	// This can be used along side AddCustomGET() and AddCustomPost() to make custom routes that use the db.
 	GetMongoClient() *mongo.Client
@@ -933,12 +938,17 @@ func (s *server) collectionAggregate(ctx *gin.Context) {
 
 // Add custom GET request, path will be under the /custom route group
 func (s *server) AddCustomGET(relativePath string, handlers ...gin.HandlerFunc) {
-	s.customRouter.GET(relativePath, handlers...)
+	s.AddCustomRoute(http.MethodGet, relativePath, handlers...)
 }
 
 // Add custom POST request, path will be under the /custom route group
 func (s *server) AddCustomPOST(relativePath string, handlers ...gin.HandlerFunc) {
-	s.customRouter.POST(relativePath, handlers...)
+	s.AddCustomRoute(http.MethodPost, relativePath, handlers...)
+}
+
+// Add a custom route for an arbitrary HTTP method, path will be under the /custom route group
+func (s *server) AddCustomRoute(method, relativePath string, handlers ...gin.HandlerFunc) {
+	s.customRouter.Handle(method, relativePath, handlers...)
 }
 
 // Returns server mongo client.

--- a/server_test.go
+++ b/server_test.go
@@ -421,6 +421,35 @@ func TestAddCustomPOST(t *testing.T) {
 	assert.JSONEq(t, `{"hello":"world"}`, w.Body.String())
 }
 
+func TestAddCustomRoute(t *testing.T) {
+	s := newTestServer(nil, "", 100, 0)
+	s.AddCustomRoute(http.MethodPut, "/widgets/:id", func(c *gin.Context) {
+		c.JSON(http.StatusOK, bson.M{"id": c.Param("id")})
+	})
+	s.createRoutes()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/custom/widgets/42", nil)
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.JSONEq(t, `{"id":"42"}`, w.Body.String())
+}
+
+func TestAddCustomRoute_MethodNotAllowedForOtherVerbs(t *testing.T) {
+	s := newTestServer(nil, "", 100, 0)
+	s.AddCustomRoute(http.MethodDelete, "/widgets/:id", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+	s.createRoutes()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/custom/widgets/42", nil)
+	s.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 // ---- GetMongoClient ----
 
 func TestGetMongoClient(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds `AddCustomRoute(method, relativePath string, handlers ...gin.HandlerFunc)` to the `Server` interface, registering a route under the `/custom` group for any HTTP method (PUT, DELETE, PATCH, etc.) via `gin.RouterGroup.Handle`.
- `AddCustomGET` and `AddCustomPOST` now delegate to `AddCustomRoute` instead of duplicating the `s.customRouter` call.
- README: documents the new method and adds it to the route table.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, container-backed tests included)
- [x] New unit tests: `TestAddCustomRoute` (PUT route registered and reachable) and `TestAddCustomRoute_MethodNotAllowedForOtherVerbs` (route only responds to its registered method)
- [x] Existing `TestAddCustomPOST` / `TestSetCustomMiddleware` still pass, confirming the delegation didn't change existing behavior

Fixes #36