### PR TITLE
Add Example functions so pkg.go.dev shows runnable docs

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,56 @@
+package gomongoapi
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// This example shows the minimal setup to stand up a server: build Options,
+// point it at a Mongo instance and default database, then Start.
+//
+// It requires a live MongoDB connection, so it is compiled but not executed
+// (no "Output:" comment).
+func ExampleNewServer() {
+	// Set server options
+	serverOpts := ServerOptions()
+	serverOpts.SetMongoClientOpts(options.Client().ApplyURI("mongodb://localhost:27017"))
+	serverOpts.SetDefaultDB("app")
+	serverOpts.SetAddress(":8080") // listen on all interfaces; default is localhost-only, see Security
+
+	// Create server
+	server := NewServer(serverOpts)
+
+	// Start server, blocks until SIGINT/SIGTERM triggers a graceful shutdown
+	// or an error occurs
+	log.Fatal(server.Start())
+}
+
+// This example adds a custom GET route under /custom that queries Mongo
+// directly via GetMongoClient.
+//
+// It requires a live MongoDB connection, so it is compiled but not executed
+// (no "Output:" comment).
+func ExampleServer_AddCustomGET() {
+	serverOpts := ServerOptions()
+	serverOpts.SetMongoClientOpts(options.Client().ApplyURI("mongodb://localhost:27017"))
+	server := NewServer(serverOpts)
+
+	// Add a custom GET route under /custom
+	server.AddCustomGET("/appUsersCount", func(ctx *gin.Context) {
+		client := server.GetMongoClient()
+
+		count, err := client.Database("app").Collection("users").CountDocuments(ctx.Request.Context(), bson.M{})
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, bson.M{"error": "Error running count: " + err.Error()})
+			return
+		}
+
+		ctx.JSON(http.StatusOK, bson.M{"Count": count})
+	})
+
+	log.Fatal(server.Start())
+}


### PR DESCRIPTION
## Summary
- Adds `example_test.go` with `ExampleNewServer` (README quick-start snippet) and `ExampleServer_AddCustomGET` (README custom-route snippet), so pkg.go.dev renders runnable documentation instead of just the package comment.
- Both examples connect to Mongo (`server.Start()`), so per the issue they're left without an `// Output:` comment — they're compiled and go-vetted, but not executed as part of `go test`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite, including container-backed tests, passes)
- [x] Confirmed via `go test -run Example -v` that the two Example functions are compiled but not run (no live Mongo connection attempted)

Fixes #37